### PR TITLE
Normalize judgeid → judge_id (snake_case)

### DIFF
--- a/src/speechwire_mcp/judges/client.py
+++ b/src/speechwire_mcp/judges/client.py
@@ -12,12 +12,12 @@ from speechwire_mcp.judges.parsers import (
 def get_judge_list(client: SpeechWireClient) -> List[Dict]:
     """Retrieve judge list with roster details from the dashboard."""
 
-    # Local _parse wrapper filters out records with None judgeid (business logic,
+    # Local _parse wrapper filters out records with None judge_id (business logic,
     # not parsing) — this pattern is used when post-processing is needed after
     # HTML parsing. See get_judge_availability for comparison (no wrapper needed).
     def _parse(html: str) -> List[Dict]:
         records = parse_judge_list_from_html(html)
-        return [r for r in records if r.get("judgeid") is not None]
+        return [r for r in records if r.get("judge_id") is not None]
 
     return _fetch_and_parse(
         client,
@@ -31,15 +31,15 @@ def get_judge_list(client: SpeechWireClient) -> List[Dict]:
 def get_judge_contact(judge_id: int, client: SpeechWireClient) -> Dict:
     """Fetch judge edit page and return contact information.
 
-    Returns a dict with judgeid, email, phone.
+    Returns a dict with judge_id, email, phone.
     """
 
-    # Local _parse wrapper injects the judgeid parameter into the result (business
+    # Local _parse wrapper injects the judge_id parameter into the result (business
     # logic, not parsing). The parser only extracts email/phone from HTML.
     def _parse(html: str) -> Dict:
         parsed = parse_judge_edit_contact_html(html)
         return {
-            "judgeid": judge_id,
+            "judge_id": judge_id,
             "email": parsed.get("email"),
             "phone": parsed.get("phone"),
         }
@@ -49,7 +49,7 @@ def get_judge_contact(judge_id: int, client: SpeechWireClient) -> Dict:
         f"https://manage.speechwire.com/tabroom/view-judge.php?judgeid={judge_id}",
         _parse,
         default={
-            "judgeid": judge_id,
+            "judge_id": judge_id,
             "email": None,
             "phone": None,
         },
@@ -73,13 +73,13 @@ def get_judge_availability(
 def get_judge_school(judge_id: int, client: SpeechWireClient) -> Dict:
     """Fetch judge edit page and return school association.
 
-    Returns a dict with judgeid, school, and team_id.
+    Returns a dict with judge_id, school, and team_id.
     """
 
     def _parse(html: str) -> Dict:
         parsed = parse_school_from_edit_html(html)
         return {
-            "judgeid": judge_id,
+            "judge_id": judge_id,
             "school": parsed.get("school"),
             "team_id": parsed.get("team_id"),
         }
@@ -89,7 +89,7 @@ def get_judge_school(judge_id: int, client: SpeechWireClient) -> Dict:
         f"https://manage.speechwire.com/tabroom/judges-edit.php?judgeid={judge_id}",
         _parse,
         default={
-            "judgeid": judge_id,
+            "judge_id": judge_id,
             "school": None,
             "team_id": None,
         },

--- a/src/speechwire_mcp/judges/parsers.py
+++ b/src/speechwire_mcp/judges/parsers.py
@@ -31,7 +31,7 @@ def parse_judge_list_from_html(html: str) -> List[Dict]:
     Returns
     -------
     list[dict]
-        Each record contains: judgeid, name, team, team_id, is_coach,
+        Each record contains: judge_id, name, team, team_id, is_coach,
         is_active, is_clean, is_priority, unavailability, blocks.
     """
     soup = make_soup(html)
@@ -49,16 +49,16 @@ def parse_judge_list_from_html(html: str) -> List[Dict]:
         if not tds:
             continue
 
-        # Col 0: Name + judgeid + optional (Coach) indicator
+        # Col 0: Name + judge_id + optional (Coach) indicator
         name = None
-        judgeid: Optional[int] = None
+        judge_id: Optional[int] = None
         is_coach = False
         name_td = td_safe(tds, 0)
         if name_td:
             name_link = name_td.find("a")
             if name_link:
                 name = name_link.get_text(strip=True) or None
-                judgeid = extract_int_query_param(name_link, "judgeid")
+                judge_id = extract_int_query_param(name_link, "judgeid")
             td_text = name_td.get_text(" ", strip=True)
             if "(Coach)" in td_text:
                 is_coach = True
@@ -102,7 +102,7 @@ def parse_judge_list_from_html(html: str) -> List[Dict]:
                 blocks = [b.strip() for b in raw.split("<br/>") if b.strip()]
 
         records.append({
-            "judgeid": judgeid,
+            "judge_id": judge_id,
             "name": name,
             "team": team,
             "team_id": team_id,

--- a/src/speechwire_mcp/server.py
+++ b/src/speechwire_mcp/server.py
@@ -256,7 +256,7 @@ def speechwire_list_judges() -> list[dict]:
     """List all judges registered for the tournament with roster details.
 
     Returns a list of records, each containing:
-    - judgeid: int — numeric judge identifier
+    - judge_id: int — numeric judge identifier
     - name: str — judge's full name
     - team: str | None — school or team name
     - team_id: int | None — numeric team identifier
@@ -284,12 +284,12 @@ def speechwire_get_judge_contact(judge_id: int) -> dict:
     judge_id : int
         Numeric judge identifier from speechwire_list_judges.
 
-    Returns a dict with judgeid, email, and phone fields.
+    Returns a dict with judge_id, email, and phone fields.
     """
     return _safe_tool_call(
         lambda: get_judge_contact(judge_id, _get_client()),
         f"Failed to get contact for judge {judge_id}",
-        default={"error": "contact_fetch_failed", "judgeid": judge_id},
+        default={"error": "contact_fetch_failed", "judge_id": judge_id},
         require_tournament=True,
     )
 
@@ -325,12 +325,12 @@ def speechwire_get_judge_school(judge_id: int) -> dict:
     judge_id : int
         Numeric judge identifier from speechwire_list_judges.
 
-    Returns a dict with judgeid, school name, and team_id.
+    Returns a dict with judge_id, school name, and team_id.
     """
     return _safe_tool_call(
         lambda: get_judge_school(judge_id, _get_client()),
         f"Failed to get school for judge {judge_id}",
-        default={"error": "school_fetch_failed", "judgeid": judge_id},
+        default={"error": "school_fetch_failed", "judge_id": judge_id},
         require_tournament=True,
     )
 

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -66,7 +66,7 @@ def test_parse_availability_basic():
 # ---------------------------------------------------------------------------
 
 def _make_judge_row(
-    judgeid=1,
+    judge_id=1,
     name="Test Judge",
     team="Test School",
     teamid=10,
@@ -92,19 +92,19 @@ def _make_judge_row(
     blocks_html = "<br/>".join(blocks) if blocks else ""
     return (
         f"<tr>"
-        f"<td><a href='view-judge.php?judgeid={judgeid}'>{name}</a>{coach_suffix}</td>"
+        f"<td><a href='view-judge.php?judgeid={judge_id}'>{name}</a>{coach_suffix}</td>"
         f"{team_cell}"
         f"<td></td>"  # edit button
         f"<td>N/A</td>"  # type
-        f"<td><select name='judgeinactive[{judgeid}]'>"
+        f"<td><select name='judgeinactive[{judge_id}]'>"
         f"<option value='0'{' selected' if active_val == '0' else ''}>ACTIVE</option>"
         f"<option value='1'{' selected' if active_val == '1' else ''}></option>"
         f"</select></td>"
-        f"<td><select name='judgeisclean[{judgeid}]'>"
+        f"<td><select name='judgeisclean[{judge_id}]'>"
         f"<option value='0'{' selected' if clean_val == '0' else ''}></option>"
         f"<option value='1'{' selected' if clean_val == '1' else ''}>CLEAN</option>"
         f"</select></td>"
-        f"<td><select name='judgepriorityupd[{judgeid}]'>"
+        f"<td><select name='judgepriorityupd[{judge_id}]'>"
         f"<option value='0'{' selected' if priority_val == '0' else ''}></option>"
         f"<option value='1'{' selected' if priority_val == '1' else ''}>PRIORITY</option>"
         f"</select></td>"
@@ -125,7 +125,7 @@ def _wrap_table(*rows):
 
 def test_judge_list_happy_path():
     html = _wrap_table(_make_judge_row(
-        judgeid=42, name="Jane Doe", team="Chesapeake Prep", teamid=7,
+        judge_id=42, name="Jane Doe", team="Chesapeake Prep", teamid=7,
         active_val="0", clean_val="1", priority_val="1",
         email="jane@example.com", unavail="Sat., 8:00 AM-5:00 PM",
         blocks=["GROUPING: Varsity Policy Debate", "GROUPING: JV Policy Debate"],
@@ -133,7 +133,7 @@ def test_judge_list_happy_path():
     records = parse_judge_list_from_html(html)
     assert len(records) == 1
     r = records[0]
-    assert r["judgeid"] == 42
+    assert r["judge_id"] == 42
     assert r["name"] == "Jane Doe"
     assert r["team"] == CHESAPEAKE_PREP
     assert r["team_id"] == 7
@@ -146,7 +146,7 @@ def test_judge_list_happy_path():
 
 
 def test_judge_list_inactive_judge():
-    html = _wrap_table(_make_judge_row(judgeid=5, active_val="1"))
+    html = _wrap_table(_make_judge_row(judge_id=5, active_val="1"))
     r = parse_judge_list_from_html(html)[0]
     assert r["is_active"] is False
 
@@ -193,7 +193,7 @@ def test_judge_list_minimal_row():
         "</table>"
     )
     r = parse_judge_list_from_html(html)[0]
-    assert r["judgeid"] == 99
+    assert r["judge_id"] == 99
     assert r["name"] == "Minimal"
     assert r["team"] is None
     assert r["team_id"] is None
@@ -212,7 +212,7 @@ def test_judge_list_minimal_row():
 
 def test_judge_list_coach_true():
     """Judge with (Coach) indicator should have is_coach=True."""
-    html = _wrap_table(_make_judge_row(judgeid=102, name="Donna Moss", coach=True))
+    html = _wrap_table(_make_judge_row(judge_id=102, name="Donna Moss", coach=True))
     r = parse_judge_list_from_html(html)[0]
     assert r["is_coach"] is True
     assert r["name"] == DONNA_MOSS
@@ -220,7 +220,7 @@ def test_judge_list_coach_true():
 
 def test_judge_list_coach_false():
     """Judge without (Coach) indicator should have is_coach=False."""
-    html = _wrap_table(_make_judge_row(judgeid=50, name="Regular Judge", coach=False))
+    html = _wrap_table(_make_judge_row(judge_id=50, name="Regular Judge", coach=False))
     r = parse_judge_list_from_html(html)[0]
     assert r["is_coach"] is False
     assert r["name"] == "Regular Judge"
@@ -229,9 +229,9 @@ def test_judge_list_coach_false():
 def test_judge_list_mixed_coach_and_non_coach():
     """Table with both coach and non-coach judges."""
     html = _wrap_table(
-        _make_judge_row(judgeid=1, name="Coach Person", coach=True),
-        _make_judge_row(judgeid=2, name="Volunteer Judge", coach=False),
-        _make_judge_row(judgeid=3, name="Another Coach", coach=True),
+        _make_judge_row(judge_id=1, name="Coach Person", coach=True),
+        _make_judge_row(judge_id=2, name="Volunteer Judge", coach=False),
+        _make_judge_row(judge_id=3, name="Another Coach", coach=True),
     )
     records = parse_judge_list_from_html(html)
     assert len(records) == 3
@@ -241,10 +241,10 @@ def test_judge_list_mixed_coach_and_non_coach():
 
 
 def test_judge_list_backward_compat():
-    """Existing judgeid/name fields must remain present and correct."""
-    html = _wrap_table(_make_judge_row(judgeid=33, name="Old Name"))
+    """Existing judge_id/name fields must remain present and correct."""
+    html = _wrap_table(_make_judge_row(judge_id=33, name="Old Name"))
     r = parse_judge_list_from_html(html)[0]
-    assert "judgeid" in r and r["judgeid"] == 33
+    assert "judge_id" in r and r["judge_id"] == 33
     assert "name" in r and r["name"] == "Old Name"
 
 
@@ -259,13 +259,13 @@ def test_judge_list_no_table():
 
 def test_judge_list_multiple_rows():
     html = _wrap_table(
-        _make_judge_row(judgeid=1, name="A", active_val="0"),
-        _make_judge_row(judgeid=2, name="B", active_val="1"),
+        _make_judge_row(judge_id=1, name="A", active_val="0"),
+        _make_judge_row(judge_id=2, name="B", active_val="1"),
     )
     records = parse_judge_list_from_html(html)
     assert len(records) == 2
-    assert records[0]["judgeid"] == 1 and records[0]["is_active"] is True
-    assert records[1]["judgeid"] == 2 and records[1]["is_active"] is False
+    assert records[0]["judge_id"] == 1 and records[0]["is_active"] is True
+    assert records[1]["judge_id"] == 2 and records[1]["is_active"] is False
 
 
 def test_judge_list_blocks_multiple():


### PR DESCRIPTION
Standardizes the `judgeid` dict key and variable name to `judge_id` across the codebase, matching the snake_case convention already used in `schematics/parsers.py`.

### Changed
- **`judges/parsers.py`** — local var + dict key → `judge_id`
- **`judges/client.py`** — dict keys + docstrings → `judge_id`
- **`server.py`** — docstrings + error-default dict keys → `judge_id`
- **`tests/test_parsers.py`** — `_make_judge_row` param + all assertions → `judge_id`

### Unchanged
- URL query params (`?judgeid=`, `firstjudgeid=`) — SpeechWire's external API
- HTML form field names (`judgeinactive`, `judgeisclean`, etc.)
- `extract_int_query_param(link, "judgeid")` calls — parsing URL params

All 153 tests pass, ruff clean.