### PR TITLE
feat: Add historical tournament support

### DIFF
--- a/src/speechwire_mcp/client.py
+++ b/src/speechwire_mcp/client.py
@@ -245,23 +245,6 @@ class SpeechWireClient:
                 options=accounts,
             )
 
-    def _auto_select_tournament(self) -> None:
-        """Discover tournaments and auto-select if exactly one exists."""
-        tournaments = self.discover_tournaments()
-        if len(tournaments) == 1:
-            t = tournaments[0]
-            self.select_tournament(t["tournament_id"], t["circuit_id"])
-            logger.info("Auto-selected sole tournament: %s", t.get("name"))
-        elif len(tournaments) == 0:
-            raise SpeechWireAuthError(
-                "No tournaments found for this account."
-            )
-        else:
-            raise SpeechWireSelectionRequired(
-                "Multiple tournaments available — please select one.",
-                options=tournaments,
-            )
-
     # ------------------------------------------------------------------
     # Convenience wrappers
     # ------------------------------------------------------------------
@@ -293,8 +276,6 @@ class SpeechWireClient:
 
         if self.tournament_id and self.circuit_id:
             self.select_tournament(self.tournament_id, self.circuit_id)
-        else:
-            self._auto_select_tournament()
 
     # ------------------------------------------------------------------
     # HTTP helpers

--- a/src/speechwire_mcp/login/client.py
+++ b/src/speechwire_mcp/login/client.py
@@ -40,7 +40,7 @@ def get_accounts(client: SpeechWireClient) -> list[dict]:
 
 
 def get_tournaments(client: SpeechWireClient) -> list[dict]:
-    """Fetch and parse the tournaments for the selected account.
+    """Fetch and parse all tournaments (current and past seasons).
 
     The client must be in ``ACCOUNT_SELECTED`` (or later) state.
 
@@ -52,8 +52,9 @@ def get_tournaments(client: SpeechWireClient) -> list[dict]:
     Returns
     -------
     list[dict]
-        Each dict has ``tournament_id`` (int), ``circuit_id`` (int),
-        ``name`` (str), and ``date`` (str | None).
+        Each dict has ``tournament_id`` (int), ``circuit_id`` (int | None),
+        ``name`` (str), ``date`` (str | None), and ``season`` (str, either
+        ``"current"`` or ``"past"``).
     """
     return _fetch_and_parse(
         client,

--- a/src/speechwire_mcp/login/parsers.py
+++ b/src/speechwire_mcp/login/parsers.py
@@ -64,12 +64,16 @@ def _extract_date_from_name(name: str) -> str | None:
 
 
 def parse_tournament_list_html(html: str) -> list[dict]:
-    """Parse the ``c-circuit-tournaments.php`` page into a list of tournaments.
+    """Parse ``c-circuit-tournaments.php`` into current and past-season tournaments.
+
+    Returns all tournaments from both the current-season form
+    (``formaddexisting``) and the historical form (``formold``), each tagged
+    with a ``season`` field.
 
     Uses three strategies in priority order:
 
-    1. ``<select name="tournid">`` inside a form (real SpeechWire HTML).
-       Only the **first** such form is processed (current-season tournaments).
+    1. ``<select name="tournid">`` inside forms (real SpeechWire HTML).
+       Processes **all** matching forms, not just the first.
     2. Anchor tags with ``tournid=`` & ``circuitid=`` query params in href.
     3. Forms with hidden ``<input name="tournid">`` fields.
 
@@ -82,24 +86,41 @@ def parse_tournament_list_html(html: str) -> list[dict]:
     -------
     list[dict]
         Each dict has ``tournament_id`` (int), ``circuit_id`` (int | None),
-        ``name`` (str), and ``date`` (str | None).
+        ``name`` (str), ``date`` (str | None), and ``season`` (str, either
+        ``"current"`` or ``"past"``).
     """
     soup = make_soup(html)
     tournaments: list[dict] = []
     seen: set[int] = set()
 
-    # Strategy 1: <select name="tournid"> inside a form (real SpeechWire HTML)
-    select = soup.find("select", {"name": "tournid"})
-    if select:
-        form = select.find_parent("form")
+    # Strategy 1: <select name="tournid"> inside forms (real SpeechWire HTML).
+    # Collect all forms containing a tournid select, processing
+    # formaddexisting (current) before formold (past) so current wins dedup.
+    all_forms = soup.find_all("form")
+    select_forms: list[tuple] = []  # (form element, season str)
+    for form in all_forms:
+        select = form.find("select", {"name": "tournid"})
+        if not select:
+            continue
+        form_name = (form.get("name") or "").strip()
+        if form_name == "formold":
+            season = "past"
+        else:
+            season = "current"
+        select_forms.append((form, season))
+
+    # Sort so "current" forms come first (current < past alphabetically)
+    select_forms.sort(key=lambda t: t[1])
+
+    for form, season in select_forms:
+        select = form.find("select", {"name": "tournid"})
         circuit_id: int | None = None
-        if form:
-            circuit_input = form.find("input", {"name": "circuitid"})
-            if circuit_input:
-                try:
-                    circuit_id = int(circuit_input.get("value", ""))
-                except (ValueError, TypeError):
-                    pass
+        circuit_input = form.find("input", {"name": "circuitid"})
+        if circuit_input:
+            try:
+                circuit_id = int(circuit_input.get("value", ""))
+            except (ValueError, TypeError):
+                pass
 
         for option in select.find_all("option"):
             val = (option.get("value") or "").strip()
@@ -116,6 +137,7 @@ def parse_tournament_list_html(html: str) -> list[dict]:
                 "circuit_id": circuit_id,
                 "name": name,
                 "date": date,
+                "season": season,
             })
 
     # Strategy 2: anchor tags with tournid & circuitid in the href
@@ -135,6 +157,7 @@ def parse_tournament_list_html(html: str) -> list[dict]:
                 "circuit_id": cid,
                 "name": name,
                 "date": date,
+                "season": "current",
             })
 
     # Strategy 3: forms with hidden inputs
@@ -160,6 +183,7 @@ def parse_tournament_list_html(html: str) -> list[dict]:
                 "circuit_id": cid,
                 "name": label,
                 "date": None,
+                "season": "current",
             })
 
     return tournaments

--- a/src/speechwire_mcp/server.py
+++ b/src/speechwire_mcp/server.py
@@ -202,9 +202,10 @@ def speechwire_select_user_account(account_id: int) -> dict:
 
 @mcp.tool()
 def speechwire_list_user_tournaments() -> list[dict]:
-    """List tournaments available for the selected account.
+    """List all tournaments (current and past seasons) for the selected account.
 
-    Returns a list with: tournament_id (int), circuit_id (int), name (str).
+    Returns a list with: tournament_id (int), circuit_id (int | None),
+    name (str), date (str | None), season (str: "current" or "past").
     Call speechwire_select_user_tournament to choose one.
     """
     return _safe_tool_call(

--- a/tests/test_login_parsers.py
+++ b/tests/test_login_parsers.py
@@ -15,9 +15,7 @@ try:
         parse_tournament_list_html,
     )
 except ImportError:
-    pytestmark = pytest.mark.skip(
-        reason="speechwire_mcp.login.parsers not implemented yet"
-    )
+    pytestmark = pytest.mark.skip(reason="speechwire_mcp.login.parsers not implemented yet")
     parse_account_list_html = None  # type: ignore[assignment]
     parse_tournament_list_html = None  # type: ignore[assignment]
 
@@ -266,6 +264,7 @@ REAL_SPEECHWIRE_DATE_RANGE_HTML = """<html><body>
 # Tests — parse_account_list_html
 # ---------------------------------------------------------------------------
 
+
 class TestParseAccountListHtml:
     def test_single_account(self):
         result = parse_account_list_html(SINGLE_ACCOUNT_HTML)
@@ -316,6 +315,7 @@ class TestParseAccountListHtml:
 # ---------------------------------------------------------------------------
 # Tests — parse_tournament_list_html
 # ---------------------------------------------------------------------------
+
 
 class TestParseTournamentListHtml:
     def test_single_tournament(self):
@@ -369,6 +369,7 @@ class TestParseTournamentListHtml:
         assert "tournament_id" in rec
         assert "circuit_id" in rec
         assert "name" in rec
+        assert "season" in rec
 
     def test_date_field_present_when_available(self):
         result = parse_tournament_list_html(SINGLE_TOURNAMENT_HTML)
@@ -380,17 +381,12 @@ class TestParseTournamentListHtml:
 class TestParseTournamentListSelectStrategy:
     """Tests for Strategy 1: <select name="tournid"> (real SpeechWire HTML)."""
 
-    def test_real_html_extracts_current_season_only(self):
+    def test_real_html_extracts_all_seasons(self):
         result = parse_tournament_list_html(REAL_SPEECHWIRE_HTML)
-        # Should only get 3 tournaments from formaddexisting, not the 2 from formold
-        assert len(result) == 3
-        tourn_ids = [r["tournament_id"] for r in result]
-        assert 20022 in tourn_ids
-        assert 20074 in tourn_ids
-        assert 21289 in tourn_ids
-        # Historical tournaments should NOT appear
-        assert 10001 not in tourn_ids
-        assert 10002 not in tourn_ids
+        # 3 current + 2 past tournaments
+        assert len(result) == 5
+        tourn_ids = {r["tournament_id"] for r in result}
+        assert tourn_ids == {20022, 20074, 21289, 10001, 10002}
 
     def test_real_html_extracts_circuit_id(self):
         result = parse_tournament_list_html(REAL_SPEECHWIRE_HTML)
@@ -440,6 +436,7 @@ class TestParseTournamentListSelectStrategy:
             assert "circuit_id" in rec
             assert "name" in rec
             assert "date" in rec
+            assert "season" in rec
 
 
 # ---------------------------------------------------------------------------
@@ -553,6 +550,7 @@ DATE_RANGE_OPTION_HTML = """<!DOCTYPE html>
 # Tests — parse_tournament_list_html (select-dropdown strategy)
 # ---------------------------------------------------------------------------
 
+
 class TestParseTournamentSelectDropdown:
     """Tests for the real SpeechWire HTML format using <select> dropdowns."""
 
@@ -578,19 +576,15 @@ class TestParseTournamentSelectDropdown:
         assert "Oct" in by_id[20022]["date"]
         assert "2025" in by_id[20022]["date"]
 
-    def test_parse_tournaments_skips_past_seasons(self):
-        """Only the first <select name='tournid'> form (current season) is used."""
+    def test_parse_tournaments_includes_all_seasons(self):
+        """Both formaddexisting (current) and formold (past) tournaments returned."""
         result = parse_tournament_list_html(CURRENT_AND_PAST_SEASONS_HTML)
         assert isinstance(result, list)
-        # Only 2 tournaments from the first (current) form
-        assert len(result) == 2
+        # 2 current + 3 past
+        assert len(result) == 5
 
         ids = {r["tournament_id"] for r in result}
-        assert ids == {20022, 20074}
-        # Past-season IDs should NOT be present
-        assert 18001 not in ids
-        assert 18002 not in ids
-        assert 18003 not in ids
+        assert ids == {20022, 20074, 18001, 18002, 18003}
 
     def test_parse_tournaments_no_date_in_name(self):
         """Option text with no parenthesized date → date should be None."""
@@ -625,3 +619,164 @@ class TestParseTournamentSelectDropdown:
 
         assert by_id[5002]["date"] is not None
         assert "Mar" in by_id[5002]["date"]
+
+
+# ---------------------------------------------------------------------------
+# HTML fixtures — historical tournament support
+# ---------------------------------------------------------------------------
+
+PAST_ONLY_HTML = """<!DOCTYPE html>
+<html><body>
+  <form action="c-circuit-tournaments.php" method="post"
+        name="formold" id="formold">
+    <select id='tournidold' name='tournid'>
+      <option value='4361'>Bartlet Middle Scrimmage (Dec. 12, 2015)</option>
+      <option value='4500'>Rosslyn Spring Classic (Mar. 5, 2016)</option>
+    </select>
+    <input name='circuitid' type="hidden" value="25" />
+  </form>
+</body></html>
+"""
+
+DUPLICATE_ACROSS_FORMS_HTML = """<!DOCTYPE html>
+<html><body>
+  <form name="formaddexisting">
+    <select name='tournid'>
+      <option value='20022'>Bartlet Invitational (Oct. 25, 2025)</option>
+    </select>
+    <input name='circuitid' type="hidden" value="25" />
+  </form>
+  <form name="formold">
+    <select name='tournid'>
+      <option value='20022'>Bartlet Invitational Archived (Oct. 25, 2024)</option>
+    </select>
+    <input name='circuitid' type="hidden" value="25" />
+  </form>
+</body></html>
+"""
+
+PAST_MISSING_CIRCUIT_HTML = """<!DOCTYPE html>
+<html><body>
+  <form name="formold">
+    <select name='tournid'>
+      <option value='5555'>Kennison Throwback (Jan. 15, 2018)</option>
+    </select>
+  </form>
+</body></html>
+"""
+
+PAST_DATE_RANGE_HTML = """<!DOCTYPE html>
+<html><body>
+  <form name="formold">
+    <select name='tournid'>
+      <option value='4988'>Rosslyn Season Opener (Sep. 16-17, 2016)</option>
+    </select>
+    <input name='circuitid' type="hidden" value="25" />
+  </form>
+</body></html>
+"""
+
+
+# ---------------------------------------------------------------------------
+# Tests — historical tournament behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestParseTournamentListHistorical:
+    """Tests for historical (past-season) tournament parsing."""
+
+    def test_both_seasons_returned(self):
+        """CURRENT_AND_PAST_SEASONS_HTML returns 5 tournaments (2 current + 3 past)."""
+        result = parse_tournament_list_html(CURRENT_AND_PAST_SEASONS_HTML)
+        assert len(result) == 5
+
+    def test_current_season_tagged(self):
+        """Tournaments from formaddexisting are tagged season='current'."""
+        result = parse_tournament_list_html(CURRENT_AND_PAST_SEASONS_HTML)
+        current = [r for r in result if r["tournament_id"] in {20022, 20074}]
+        assert len(current) == 2
+        for rec in current:
+            assert rec["season"] == "current"
+
+    def test_past_season_tagged(self):
+        """Tournaments from formold are tagged season='past'."""
+        result = parse_tournament_list_html(CURRENT_AND_PAST_SEASONS_HTML)
+        past = [r for r in result if r["tournament_id"] in {18001, 18002, 18003}]
+        assert len(past) == 3
+        for rec in past:
+            assert rec["season"] == "past"
+
+    def test_circuit_id_extracted_for_both_seasons(self):
+        """All records from both forms have circuit_id == 25."""
+        result = parse_tournament_list_html(CURRENT_AND_PAST_SEASONS_HTML)
+        for rec in result:
+            assert rec["circuit_id"] == 25
+
+    def test_dates_extracted_for_both_seasons(self):
+        """Dates are present for both current and past tournaments."""
+        result = parse_tournament_list_html(CURRENT_AND_PAST_SEASONS_HTML)
+        for rec in result:
+            assert rec["date"] is not None
+            assert isinstance(rec["date"], str)
+            assert len(rec["date"]) > 0
+
+    def test_current_only_page(self):
+        """SELECT_DROPDOWN_HTML (no formold): 3 tournaments, all season='current'."""
+        result = parse_tournament_list_html(SELECT_DROPDOWN_HTML)
+        assert len(result) == 3
+        for rec in result:
+            assert rec["season"] == "current"
+
+    def test_past_only_page(self):
+        """PAST_ONLY_HTML: 2 tournaments, all season='past'."""
+        result = parse_tournament_list_html(PAST_ONLY_HTML)
+        assert len(result) == 2
+        ids = {r["tournament_id"] for r in result}
+        assert ids == {4361, 4500}
+        for rec in result:
+            assert rec["season"] == "past"
+
+    def test_empty_page(self):
+        """NO_SELECT_PLAIN_PAGE_HTML: returns empty list."""
+        result = parse_tournament_list_html(NO_SELECT_PLAIN_PAGE_HTML)
+        assert result == []
+
+    def test_empty_selects(self):
+        """EMPTY_SELECT_HTML: returns empty list."""
+        result = parse_tournament_list_html(EMPTY_SELECT_HTML)
+        assert result == []
+
+    def test_all_records_have_season_key(self):
+        """Every record from CURRENT_AND_PAST_SEASONS_HTML has a 'season' key."""
+        result = parse_tournament_list_html(CURRENT_AND_PAST_SEASONS_HTML)
+        for rec in result:
+            assert "season" in rec
+
+    def test_deduplication_across_forms(self):
+        """Same tournament_id in both forms appears once, tagged 'current'."""
+        result = parse_tournament_list_html(DUPLICATE_ACROSS_FORMS_HTML)
+        assert len(result) == 1
+        assert result[0]["tournament_id"] == 20022
+        assert result[0]["season"] == "current"
+
+    def test_past_missing_circuit_id(self):
+        """Past form with no circuitid hidden input -> circuit_id is None."""
+        result = parse_tournament_list_html(PAST_MISSING_CIRCUIT_HTML)
+        assert len(result) == 1
+        assert result[0]["tournament_id"] == 5555
+        assert result[0]["circuit_id"] is None
+        assert result[0]["season"] == "past"
+
+    def test_past_date_range(self):
+        """Date range like 'Sep. 16-17, 2016' extracted correctly from past form."""
+        result = parse_tournament_list_html(PAST_DATE_RANGE_HTML)
+        assert len(result) == 1
+        assert result[0]["date"] == "Sep. 16-17, 2016"
+        assert result[0]["season"] == "past"
+
+    def test_season_values_are_valid(self):
+        """All season values are either 'current' or 'past'."""
+        result = parse_tournament_list_html(CURRENT_AND_PAST_SEASONS_HTML)
+        valid_seasons = {"current", "past"}
+        for rec in result:
+            assert rec["season"] in valid_seasons


### PR DESCRIPTION
## Summary

Adds support for historical (past-season) tournaments. The SpeechWire tournament selection page has two forms — `formaddexisting` (current season) and `formold` (past seasons). Previously, only the current-season form was parsed.

## Changes

### Parser (`login/parsers.py`)
- Modified `parse_tournament_list_html()` to process **all** forms, not just the first
- Each tournament record now includes a `season` field: `"current"` or `"past"`
- Deduplication preserves current-season tournaments when IDs overlap
- Strategies 2 & 3 (anchor tags, hidden inputs) also emit `season: "current"`

### Client (`client.py`)
- **Removed `_auto_select_tournament()`** — users now always select tournaments explicitly via MCP tools
- Updated `_authenticate()` to skip tournament auto-selection when no IDs are provided

### Docstrings (`login/client.py`, `server.py`)
- Updated `get_tournaments()` and `speechwire_list_user_tournaments` docstrings to reflect the new `season` field

### Tests (`test_login_parsers.py`)
- Updated 4 existing tests for new behavior (parser now returns all seasons)
- Added 14 new tests in `TestParseTournamentListHistorical` covering season tagging, deduplication, edge cases
- Added 4 new HTML fixtures

## Data shape

```python
{"tournament_id": int, "circuit_id": int | None, "name": str, "date": str | None, "season": "current" | "past"}
```

## Breaking changes

- `parse_tournament_list_html()` now returns past-season tournaments (previously only current)
- `_auto_select_tournament()` removed — callers must select tournaments explicitly
- Tournament records now include a `season` key

## Test results

All 60 tests pass.