### PR TITLE
fix: Prevent infinite recursion in session-expiry handler

### DIFF
--- a/src/speechwire_mcp/client.py
+++ b/src/speechwire_mcp/client.py
@@ -78,6 +78,7 @@ class SpeechWireClient:
         self.tournament_id = tournament_id
         self.session = requests.Session()
         self.state = ClientState.UNAUTHENTICATED
+        self._reauthenticating = False
 
     # ------------------------------------------------------------------
     # Phased auth methods
@@ -322,11 +323,16 @@ class SpeechWireClient:
 
         If the response looks like an expired session (login page redirect
         or unexpected tournament-selection text), the client re-authenticates
-        and retries the request once.
+        and retries the request once.  A guard prevents infinite recursion
+        when ``_authenticate`` itself issues GETs (e.g. account discovery).
         """
         resp = self.session.get(url)
-        if self._looks_like_expired_session(resp):
-            self._authenticate()
+        if self._looks_like_expired_session(resp) and not self._reauthenticating:
+            self._reauthenticating = True
+            try:
+                self._authenticate()
+            finally:
+                self._reauthenticating = False
             resp = self.session.get(url)
         return resp
 

--- a/tests/test_client_state.py
+++ b/tests/test_client_state.py
@@ -192,6 +192,35 @@ class TestStateGating:
             with pytest.raises(Exception):
                 client.ensure_tournament_session()
 
+    def test_get_no_recursion_on_expired_session(self):
+        """get() must not recurse when _authenticate also triggers get()."""
+        from unittest.mock import patch, MagicMock
+
+        SpeechWireClient = _import_client()
+        client = SpeechWireClient(email="u@x.com", password="p")
+
+        expired_resp = MagicMock()
+        expired_resp.text = '<input type="password" />'
+        expired_resp.url = "https://manage.speechwire.com/tabroom/judges.php"
+
+        client.session.get = MagicMock(return_value=expired_resp)
+
+        call_count = 0
+
+        def fake_authenticate():
+            nonlocal call_count
+            call_count += 1
+            if call_count > 5:
+                raise RuntimeError("recursion detected")
+            # Simulate what _authenticate does: call get() again
+            client.get("https://www.speechwire.com/c-account-select.php")
+
+        with patch.object(client, "_authenticate", side_effect=fake_authenticate):
+            client.get("https://www.speechwire.com/c-account-select.php")
+
+        # _authenticate should only be called once, not recursively
+        assert call_count == 1
+
 
 # ---------------------------------------------------------------------------
 # Tests — _require_tournament backward-compatibility guard


### PR DESCRIPTION
## Bug

`get()` → `_looks_like_expired_session()` → `_authenticate()` → `_auto_select_account()` → `discover_accounts()` → `get()` → ♻️ **infinite recursion**

The account-select page (`c-account-select.php`) contains a password field in SpeechWire's page chrome, causing `_looks_like_expired_session()` to return `True`. This triggers re-auth, which discovers accounts via `get()`, which detects the same 'expired' signal, and so on — until `RecursionError`.

**Impact:** Any code path using the step-by-step login flow (login → list accounts → select) hits this. The env-var flow (`ensure_tournament_session` with all IDs) was unaffected because `_authenticate()` skips discovery when IDs are pre-set.

## Fix

Added a `_reauthenticating` guard flag on `SpeechWireClient`. When `get()` enters re-auth, the flag prevents nested `get()` calls from triggering re-auth again. The flag is reset via `try/finally` so it's always cleaned up.

## Test

Added `test_get_no_recursion_on_expired_session` — simulates the exact scenario (every response triggers expired-session detection) and verifies `_authenticate` is called exactly once.

**16 tests pass.**