### PR TITLE
feat: include email in speechwire_list_judges output

### DIFF
--- a/src/speechwire_mcp/judges/parsers.py
+++ b/src/speechwire_mcp/judges/parsers.py
@@ -32,7 +32,7 @@ def parse_judge_list_from_html(html: str) -> List[Dict]:
     -------
     list[dict]
         Each record contains: judge_id, name, team, team_id, is_coach,
-        is_active, is_clean, is_priority, unavailability, blocks.
+        is_active, is_clean, is_priority, email, unavailability, blocks.
     """
     soup = make_soup(html)
     table = soup.find("table", class_="dd")
@@ -85,6 +85,14 @@ def parse_judge_list_from_html(html: str) -> List[Dict]:
         prio_val = _selected_value(td_safe(tds, 6), "judgepriorityupd")
         is_priority = prio_val == "1" if prio_val is not None else False
 
+        # Col 7: Email address
+        email: str | None = None
+        email_td = td_safe(tds, 7)
+        if email_td:
+            email_match = _EMAIL_RE.search(email_td.get_text(" ", strip=True))
+            if email_match:
+                email = email_match.group(0).lower()
+
         # Col 8: Unavailability text
         unavail_td = td_safe(tds, 8)
         unavailability: Optional[str] = None
@@ -111,6 +119,7 @@ def parse_judge_list_from_html(html: str) -> List[Dict]:
                 "is_active": is_active,
                 "is_clean": is_clean,
                 "is_priority": is_priority,
+                "email": email,
                 "unavailability": unavailability,
                 "blocks": blocks,
             }

--- a/src/speechwire_mcp/server.py
+++ b/src/speechwire_mcp/server.py
@@ -265,6 +265,7 @@ def speechwire_list_judges() -> list[dict]:
     - is_active: bool — whether the judge is active
     - is_clean: bool — whether the judge is marked clean
     - is_priority: bool — whether the judge is marked priority
+    - email: str | None — judge's email address (if present on the roster page)
     - unavailability: str | None — unavailability summary text
     - blocks: list[str] — event/team blocks (e.g. "GROUPING: Varsity Policy Debate")
     """

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -6,6 +6,7 @@ from fake_data import (
     ROSSLYN_ACADEMY,
     POTOMAC_ACADEMY,
     CHESAPEAKE_PREP,
+    email_for,
 )
 from speechwire_mcp.judges.parsers import (
     parse_judge_edit_contact_html,
@@ -157,6 +158,7 @@ def test_judge_list_happy_path():
     assert r["unavailability"] == "Sat., 8:00 AM-5:00 PM"
     assert r["blocks"] == ["GROUPING: Varsity Policy Debate", "GROUPING: JV Policy Debate"]
     assert r["is_coach"] is False
+    assert r["email"] == "jane@example.com"
 
 
 def test_judge_list_inactive_judge():
@@ -184,6 +186,34 @@ def test_judge_list_not_clean_not_priority():
     r = parse_judge_list_from_html(html)[0]
     assert r["is_clean"] is False
     assert r["is_priority"] is False
+
+
+# ---------------------------------------------------------------------------
+# Email extraction tests
+# ---------------------------------------------------------------------------
+
+
+def test_judge_list_email_present():
+    """Email address is extracted from column 7."""
+    html = _wrap_table(
+        _make_judge_row(judge_id=70, name="Donna Moss", email=email_for(DONNA_MOSS))
+    )
+    r = parse_judge_list_from_html(html)[0]
+    assert r["email"] == email_for(DONNA_MOSS)
+
+
+def test_judge_list_email_absent():
+    """Missing email yields None."""
+    html = _wrap_table(_make_judge_row(judge_id=71, email=""))
+    r = parse_judge_list_from_html(html)[0]
+    assert r["email"] is None
+
+
+def test_judge_list_email_normalised_to_lowercase():
+    """Email addresses are lowercased."""
+    html = _wrap_table(_make_judge_row(judge_id=72, email="Jane.Doe@Example.COM"))
+    r = parse_judge_list_from_html(html)[0]
+    assert r["email"] == "jane.doe@example.com"
 
 
 def test_judge_list_empty_unavailability():
@@ -214,6 +244,7 @@ def test_judge_list_minimal_row():
     assert r["is_active"] is True  # default when no select found
     assert r["is_clean"] is False
     assert r["is_priority"] is False
+    assert r["email"] is None
     assert r["unavailability"] is None
     assert r["blocks"] == []
     assert r["is_coach"] is False


### PR DESCRIPTION
## Summary

Extracts judge email addresses from column 7 of the SpeechWire roster HTML table and includes them in the `speechwire_list_judges` tool output.

### Changes

- **`judges/parsers.py`**: Parse email from column 7 using the existing `_EMAIL_RE` regex. Emails are lowercased for consistency. Returns `None` when absent.
- **`server.py`**: Updated tool docstring to document the new `email: str | None` field.
- **`tests/test_parsers.py`**: Added 3 new tests (email present, absent, case normalization) + assertions in existing happy-path and minimal-row tests.

### Output shape (new field marked with ✨)

```json
{
  "judge_id": 42,
  "name": "Jane Doe",
  "team": "Chesapeake Prep",
  "team_id": 7,
  "is_coach": false,
  "is_active": true,
  "is_clean": true,
  "is_priority": true,
  "email": "jane@example.com",   // ✨ new
  "unavailability": "Sat., 8:00 AM-5:00 PM",
  "blocks": ["GROUPING: Varsity Policy Debate"]
}
```

### Testing

All 198 tests pass. Lint clean.