### PR TITLE
feat: add results/tab sheet parser and MCP tool

### DIFF
--- a/src/speechwire_mcp/__init__.py
+++ b/src/speechwire_mcp/__init__.py
@@ -12,6 +12,7 @@ from speechwire_mcp.rooms import get_room_counts, get_room_list, get_room_usage
 from speechwire_mcp.schematics import get_schematic_events, get_round_schematic
 from speechwire_mcp.structure import get_groupings, get_timeslots
 from speechwire_mcp.teams import get_team_list, get_team_entries, get_hybrid_entries
+from speechwire_mcp.results import get_tab_sheet
 
 __all__ = [
     "SpeechWireClient",
@@ -32,4 +33,5 @@ __all__ = [
     "get_team_list",
     "get_team_entries",
     "get_hybrid_entries",
+    "get_tab_sheet",
 ]

--- a/src/speechwire_mcp/results/__init__.py
+++ b/src/speechwire_mcp/results/__init__.py
@@ -1,0 +1,3 @@
+from speechwire_mcp.results.client import get_tab_sheet
+
+__all__ = ["get_tab_sheet"]

--- a/src/speechwire_mcp/results/client.py
+++ b/src/speechwire_mcp/results/client.py
@@ -1,0 +1,41 @@
+"""HTTP retrieval functions for SpeechWire tournament results data.
+
+Each function wraps a parser with :func:`_fetch_and_parse` so that
+HTTP errors and parse failures return safe defaults.
+"""
+
+import logging
+
+from speechwire_mcp.client import SpeechWireClient, _fetch_and_parse
+from speechwire_mcp.results.parsers import parse_tab_sheet_from_html
+
+logger = logging.getLogger(__name__)
+
+_BASE = "https://manage.speechwire.com/tabroom/tab-grouping.php"
+
+
+def get_tab_sheet(grouping_id: int, client: SpeechWireClient) -> dict:
+    """Retrieve the results tab sheet for a specific grouping.
+
+    Parameters
+    ----------
+    grouping_id : int
+        Numeric grouping identifier (from ``speechwire_list_groupings``).
+    client : SpeechWireClient
+        Authenticated client with an active tournament session.
+
+    Returns
+    -------
+    dict
+        Parsed results containing ``grouping_name``, ``round_names``,
+        and ``competitors`` with round-by-round outcomes, speaker
+        scores, and placements.
+    """
+    url = f"{_BASE}?groupingid={grouping_id}&Submit=View+tab+sheet&sortby=&divisionrestrict="
+    return _fetch_and_parse(
+        client,
+        url,
+        parse_tab_sheet_from_html,
+        default={},
+        context=f"tab sheet for grouping {grouping_id}",
+    )

--- a/src/speechwire_mcp/results/parsers.py
+++ b/src/speechwire_mcp/results/parsers.py
@@ -1,0 +1,310 @@
+"""Parsers for SpeechWire tournament results (tab sheet) pages.
+
+Pure functions that convert HTML strings into structured data.
+No side effects — safe for unit testing with fixture HTML.
+"""
+
+import logging
+import re
+
+from bs4 import Tag
+
+from speechwire_mcp.parsing_helpers import make_soup, extract_int_query_param
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_round_cell(td: Tag | None) -> dict:
+    """Parse a single round-result cell from a team row.
+
+    Parameters
+    ----------
+    td : Tag | None
+        A ``<td>`` element containing a round result (W/L/BYE/FORFEIT/empty).
+
+    Returns
+    -------
+    dict
+        Keys: ``result`` (str | None), ``opponent`` (str | None),
+        ``side`` (str | None), ``judge`` (str | None),
+        ``judge_number`` (int | None).
+    """
+    empty = {
+        "result": None,
+        "opponent": None,
+        "side": None,
+        "judge": None,
+        "judge_number": None,
+    }
+    if not td:
+        return empty
+
+    text = td.get_text(separator="|", strip=True)
+    if not text or text == "\xa0":
+        return empty
+
+    strong = td.find("strong")
+    if not strong:
+        return empty
+
+    result_text = strong.get_text(strip=True)
+
+    if result_text == "BYE":
+        return {**empty, "result": "BYE"}
+    if result_text == "FORFEIT":
+        return {**empty, "result": "FORFEIT"}
+
+    if result_text not in ("W", "L"):
+        return empty
+
+    result: dict = {"result": result_text, "opponent": None, "side": None,
+                    "judge": None, "judge_number": None}
+
+    # The cell text after the strong tag looks like:
+    # "W|  - Oyster Adams PIMA - Neg|2 Margaret Kepler"
+    # Split on "|" to get segments
+    segments = text.split("|")
+
+    # Second segment has " - Opponent Name - Side"
+    if len(segments) >= 2:
+        match_text = segments[1].strip()
+        # Strip leading " - "
+        if match_text.startswith("- "):
+            match_text = match_text[2:].strip()
+
+        # Side is the last token after " - "
+        parts = match_text.rsplit(" - ", 1)
+        if len(parts) == 2:
+            result["opponent"] = parts[0].strip()
+            side_text = parts[1].strip()
+            if side_text:
+                result["side"] = side_text
+        else:
+            result["opponent"] = match_text or None
+
+    # Third segment has judge info: "2 Margaret Kepler"
+    if len(segments) >= 3:
+        judge_text = segments[2].strip()
+        judge_match = re.match(r"^(\d+)\s+(.+)$", judge_text)
+        if judge_match:
+            result["judge_number"] = int(judge_match.group(1))
+            result["judge"] = judge_match.group(2).strip()
+        elif judge_text:
+            result["judge"] = judge_text
+
+    return result
+
+
+def _parse_speaker_scores(tds: list[Tag], num_rounds: int) -> list[float | None]:
+    """Extract per-round speaker scores from a speaker row's cells.
+
+    Parameters
+    ----------
+    tds : list[Tag]
+        All ``<td>`` elements in the speaker row.
+    num_rounds : int
+        Number of round columns.
+
+    Returns
+    -------
+    list[float | None]
+        One score per round; ``None`` for empty cells.
+    """
+    scores: list[float | None] = []
+    for i in range(1, num_rounds + 1):
+        if i < len(tds):
+            text = tds[i].get_text(strip=True)
+            if text and text != "\xa0":
+                try:
+                    scores.append(float(text))
+                except ValueError:
+                    scores.append(None)
+            else:
+                scores.append(None)
+        else:
+            scores.append(None)
+    return scores
+
+
+def _parse_float(text: str) -> float | None:
+    """Parse a float from stripped text, returning None on failure."""
+    if not text or text == "\xa0":
+        return None
+    try:
+        return float(text)
+    except ValueError:
+        return None
+
+
+def parse_tab_sheet_from_html(html: str) -> dict:
+    """Parse a tab-grouping.php page into structured results data.
+
+    Parameters
+    ----------
+    html : str
+        Raw HTML from the tab-grouping.php page.
+
+    Returns
+    -------
+    dict
+        Keys:
+        - ``grouping_name`` (str) — name of the grouping
+        - ``round_names`` (list[str]) — header labels for each round column
+        - ``competitors`` (list[dict]) — one per team/competitor, containing:
+            - ``comp_id`` (int) — from the ``compid`` query parameter
+            - ``name`` (str) — team/competitor display name
+            - ``rounds`` (list[dict]) — per-round results, each with:
+                - ``round_number`` (int)
+                - ``result`` (str | None) — "W", "L", "BYE", "FORFEIT", or None
+                - ``opponent`` (str | None)
+                - ``side`` (str | None) — "AFF", "Neg", or None
+                - ``judge`` (str | None)
+                - ``judge_number`` (int | None)
+            - ``record`` (str) — e.g. "3-0"
+            - ``total_points`` (float | None) — combined speaker points
+            - ``placement`` (str) — e.g. "2nd"
+            - ``speakers`` (list[dict]) — individual speakers, each with:
+                - ``name`` (str)
+                - ``round_scores`` (list[float | None])
+                - ``total_points`` (float | None)
+                - ``placement`` (str)
+    """
+    soup = make_soup(html)
+
+    # Extract grouping name from the pagesubtitle span
+    grouping_name = ""
+    subtitle = soup.find("span", class_="pagesubtitle")
+    if subtitle:
+        grouping_name = subtitle.get_text(strip=True)
+
+    # Find the results table (table.dd with a tableheader containing "Competitor")
+    target_table = None
+    for table in soup.find_all("table", class_="dd"):
+        header = table.find("tr", class_="tableheader")
+        if header and "Competitor" in header.get_text():
+            target_table = table
+            break
+
+    if not target_table:
+        return {"grouping_name": grouping_name, "round_names": [], "competitors": []}
+
+    # Parse header to determine round column names
+    header_row = target_table.find("tr", class_="tableheader")
+    header_cells = header_row.find_all("td") if header_row else []
+    # Columns: Competitor, Round 1, ..., Round N, Totals, Results
+    # Round names are everything between "Competitor" and "Totals"
+    round_names: list[str] = []
+    for td in header_cells[1:]:
+        text = td.get_text(strip=True)
+        if text in ("Totals", "Results"):
+            break
+        if text:
+            round_names.append(text)
+
+    num_rounds = len(round_names)
+
+    # Process data rows
+    rows = target_table.find_all("tr")
+    competitors: list[dict] = []
+    current_competitor: dict | None = None
+
+    for row in rows:
+        if "tableheader" in (row.get("class") or []):
+            continue
+
+        tds = row.find_all("td")
+        if not tds:
+            continue
+
+        first_cell = tds[0]
+        # Team/competitor row: first cell contains <strong><a href='view-comp.php?compid=...'>
+        team_link = first_cell.find(
+            "a", href=lambda h: h and "view-comp.php" in h and "compid=" in h
+        )
+
+        if team_link and first_cell.find("strong"):
+            # Save previous competitor
+            if current_competitor is not None:
+                competitors.append(current_competitor)
+
+            comp_id = extract_int_query_param(team_link, "compid")
+            name = team_link.get_text(strip=True)
+
+            # Parse per-round results
+            rounds: list[dict] = []
+            for r_idx in range(num_rounds):
+                td_idx = r_idx + 1
+                round_td = tds[td_idx] if td_idx < len(tds) else None
+                round_data = _parse_round_cell(round_td)
+                round_data["round_number"] = r_idx + 1
+                rounds.append(round_data)
+
+            # Totals cell: <strong>3-0</strong><br/><span>171.3</span>
+            totals_idx = num_rounds + 1
+            record = ""
+            total_points: float | None = None
+            if totals_idx < len(tds):
+                totals_td = tds[totals_idx]
+                record_strong = totals_td.find("strong")
+                if record_strong:
+                    record = record_strong.get_text(strip=True)
+                pts_span = totals_td.find("span")
+                if pts_span:
+                    total_points = _parse_float(pts_span.get_text(strip=True))
+
+            # Results/placement cell
+            results_idx = num_rounds + 2
+            placement = ""
+            if results_idx < len(tds):
+                results_td = tds[results_idx]
+                placement_strong = results_td.find("strong")
+                if placement_strong:
+                    placement = placement_strong.get_text(strip=True)
+                else:
+                    placement = results_td.get_text(strip=True)
+
+            current_competitor = {
+                "comp_id": comp_id,
+                "name": name,
+                "rounds": rounds,
+                "record": record,
+                "total_points": total_points,
+                "placement": placement,
+                "speakers": [],
+            }
+        elif current_competitor is not None:
+            # Speaker row: plain name in first cell, scores in subsequent cells
+            speaker_name = first_cell.get_text(strip=True)
+            if not speaker_name or speaker_name == "\xa0":
+                continue
+
+            round_scores = _parse_speaker_scores(tds, num_rounds)
+
+            # Total points cell
+            total_idx = num_rounds + 1
+            spk_total: float | None = None
+            if total_idx < len(tds):
+                spk_total = _parse_float(tds[total_idx].get_text(strip=True))
+
+            # Placement cell
+            placement_idx = num_rounds + 2
+            spk_placement = ""
+            if placement_idx < len(tds):
+                spk_placement = tds[placement_idx].get_text(strip=True)
+
+            current_competitor["speakers"].append({
+                "name": speaker_name,
+                "round_scores": round_scores,
+                "total_points": spk_total,
+                "placement": spk_placement,
+            })
+
+    # Don't forget the last competitor
+    if current_competitor is not None:
+        competitors.append(current_competitor)
+
+    return {
+        "grouping_name": grouping_name,
+        "round_names": round_names,
+        "competitors": competitors,
+    }

--- a/src/speechwire_mcp/server.py
+++ b/src/speechwire_mcp/server.py
@@ -42,6 +42,7 @@ from speechwire_mcp.login import get_accounts, get_tournaments
 from speechwire_mcp.rooms import get_room_list, get_room_usage, get_room_counts
 from speechwire_mcp.teams import get_team_list, get_team_entries, get_hybrid_entries
 from speechwire_mcp.structure import get_groupings, get_timeslots
+from speechwire_mcp.results import get_tab_sheet
 
 logger = logging.getLogger(__name__)
 
@@ -649,6 +650,45 @@ def speechwire_get_round_schematic(grouping_id: int, round_number: int) -> dict 
     return _safe_tool_call(
         lambda: get_round_schematic(grouping_id, round_number, _get_client()),
         f"Failed to get schematic for grouping {grouping_id} round {round_number}",
+        default={},
+        require_tournament=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Results / Tab Sheet Tools
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+def speechwire_get_tab_sheet(grouping_id: int) -> dict | list:
+    """Get the results tab sheet for a competition grouping.
+
+    Returns round-by-round outcomes (W/L/BYE/FORFEIT), per-speaker scores,
+    win-loss records, total points, and final placements.
+
+    Parameters
+    ----------
+    grouping_id : int
+        Grouping identifier from speechwire_list_groupings.
+
+    Returns a dict containing:
+    - grouping_name: str — name of the grouping
+    - round_names: list[str] — round column headers (e.g., "Round 1")
+    - competitors: list[dict] — one per team, each with:
+        - comp_id: int — competitor identifier
+        - name: str — team display name
+        - rounds: list[dict] — per-round results with result, opponent, side,
+          judge, judge_number
+        - record: str — e.g. "3-0"
+        - total_points: float | None — combined speaker points
+        - placement: str — e.g. "2nd"
+        - speakers: list[dict] — individual speakers with name, round_scores,
+          total_points, and placement
+    """
+    return _safe_tool_call(
+        lambda: get_tab_sheet(grouping_id, _get_client()),
+        f"Failed to get tab sheet for grouping {grouping_id}",
         default={},
         require_tournament=True,
     )

--- a/tests/test_results_parsers.py
+++ b/tests/test_results_parsers.py
@@ -1,0 +1,402 @@
+"""Tests for speechwire_mcp.results.parsers — tab sheet / results parser.
+
+Uses fictional West Wing character names per project conventions.
+"""
+
+from speechwire_mcp.results.parsers import parse_tab_sheet_from_html
+
+from fake_data import (
+    JED_BARTLET,
+    LEO_MCGARRY,
+    JOSH_LYMAN,
+    SAM_SEABORN,
+    TOBY_ZIEGLER,
+    CJ_CREGG,
+    CHARLIE_YOUNG,
+    DONNA_MOSS,
+    MANCHESTER_PREP,
+    ROSSLYN_ACADEMY,
+    HARTSFIELD_LANDING,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixture HTML builders
+# ---------------------------------------------------------------------------
+
+def _build_tab_sheet_html(
+    grouping_name: str,
+    round_names: list[str],
+    competitor_blocks: list[str],
+) -> str:
+    """Build a minimal tab-grouping.php HTML page for testing."""
+    round_headers = "".join(
+        f"<td class='dd centered'>{r}</td>" for r in round_names
+    )
+    rows = "\n".join(competitor_blocks)
+    return (
+        "<html><body>"
+        f"<span class='pagesubtitle'>{grouping_name}</span>"
+        "<table class='dd'>"
+        "<tr class='tableheader'>"
+        "<td class='dd centered'>Competitor</td>"
+        f"{round_headers}"
+        "<td class='dd centered'>Totals</td>"
+        "<td class='dd centered'>Results</td>"
+        "</tr>"
+        f"{rows}"
+        "</table>"
+        "</body></html>"
+    )
+
+
+def _team_row(
+    comp_id: int,
+    name: str,
+    round_cells: list[str],
+    record: str,
+    total_points: str,
+    placement: str,
+) -> str:
+    """Build a team/competitor row."""
+    cells = "".join(f"<td class='dd centered'>{c}</td>" for c in round_cells)
+    return (
+        "<tr>"
+        f"<td class='dd centered'><strong>"
+        f"<a href='view-comp.php?compid={comp_id}'>{name}</a>"
+        f"</strong></td>"
+        f"{cells}"
+        f"<td rowspan='1' class='dd centered'><strong>{record}</strong>"
+        f"<br /><span style='font-size: 10px;'>{total_points}</span></td>"
+        f"<td rowspan='1' class='dd centered'><strong>{placement}</strong></td>"
+        "</tr>"
+    )
+
+
+def _speaker_row(
+    name: str,
+    round_scores: list[str],
+    total: str,
+    placement: str,
+) -> str:
+    """Build a speaker row."""
+    cells = "".join(f"<td class='dd centered'>{s}</td>" for s in round_scores)
+    return (
+        "<tr>"
+        f"<td class='dd centered'>{name}</td>"
+        f"{cells}"
+        f"<td class='dd centered'>{total}</td>"
+        f"<td class='dd centered'>{placement}</td>"
+        "</tr>"
+    )
+
+
+def _win_cell(opponent: str, side: str, judge_num: int, judge_name: str) -> str:
+    return (
+        f"<strong>W</strong> - {opponent} - {side}"
+        f"<br /><span style='font-size: 10px;'>{judge_num} {judge_name}</span>"
+    )
+
+
+def _loss_cell(opponent: str, side: str, judge_num: int, judge_name: str) -> str:
+    return (
+        f"<strong>L</strong> - {opponent} - {side}"
+        f"<br /><span style='font-size: 10px;'>{judge_num} {judge_name}</span>"
+    )
+
+
+def _bye_cell() -> str:
+    return "<strong>BYE</strong>&nbsp;"
+
+
+def _forfeit_cell() -> str:
+    return "<strong>FORFEIT</strong>"
+
+
+def _empty_cell() -> str:
+    return "&nbsp;"
+
+
+# ---------------------------------------------------------------------------
+# Full fixture: two teams, two rounds
+# ---------------------------------------------------------------------------
+
+SAMPLE_HTML = _build_tab_sheet_html(
+    grouping_name="Varsity Policy Debate",
+    round_names=["Round 1", "Round 2"],
+    competitor_blocks=[
+        _team_row(
+            comp_id=42,
+            name=f"{MANCHESTER_PREP} BALY",
+            round_cells=[
+                _win_cell(f"{ROSSLYN_ACADEMY} LYSE", "AFF", 5, JED_BARTLET),
+                _win_cell(f"{HARTSFIELD_LANDING} CRYO", "Neg", 12, LEO_MCGARRY),
+            ],
+            record="2-0",
+            total_points="170.5",
+            placement="1st",
+        ),
+        _speaker_row(JOSH_LYMAN, ["29.00", "28.50"], "57.50", "3rd"),
+        _speaker_row(SAM_SEABORN, ["28.50", "27.50"], "56.00", "8th"),
+        _team_row(
+            comp_id=99,
+            name=f"{ROSSLYN_ACADEMY} LYSE",
+            round_cells=[
+                _loss_cell(f"{MANCHESTER_PREP} BALY", "Neg", 5, JED_BARTLET),
+                _bye_cell(),
+            ],
+            record="1-1",
+            total_points="82.0",
+            placement="5th",
+        ),
+        _speaker_row(TOBY_ZIEGLER, ["27.00", "28.00"], "55.00", "12th"),
+        _speaker_row(CJ_CREGG, ["27.00", "27.50"], "54.50", "15th"),
+    ],
+)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_parse_tab_sheet_happy_path():
+    """Full sample HTML produces two competitors with correct structure."""
+    result = parse_tab_sheet_from_html(SAMPLE_HTML)
+
+    assert result["grouping_name"] == "Varsity Policy Debate"
+    assert result["round_names"] == ["Round 1", "Round 2"]
+    assert len(result["competitors"]) == 2
+
+
+def test_parse_tab_sheet_first_competitor():
+    """First competitor has correct IDs, rounds, record, placement."""
+    result = parse_tab_sheet_from_html(SAMPLE_HTML)
+    comp = result["competitors"][0]
+
+    assert comp["comp_id"] == 42
+    assert comp["name"] == f"{MANCHESTER_PREP} BALY"
+    assert comp["record"] == "2-0"
+    assert comp["total_points"] == 170.5
+    assert comp["placement"] == "1st"
+
+
+def test_parse_tab_sheet_round_results():
+    """Round-by-round results parse W/L with opponent, side, judge info."""
+    result = parse_tab_sheet_from_html(SAMPLE_HTML)
+    comp = result["competitors"][0]
+
+    r1 = comp["rounds"][0]
+    assert r1["round_number"] == 1
+    assert r1["result"] == "W"
+    assert r1["opponent"] == f"{ROSSLYN_ACADEMY} LYSE"
+    assert r1["side"] == "AFF"
+    assert r1["judge"] == JED_BARTLET
+    assert r1["judge_number"] == 5
+
+    r2 = comp["rounds"][1]
+    assert r2["result"] == "W"
+    assert r2["side"] == "Neg"
+    assert r2["judge"] == LEO_MCGARRY
+    assert r2["judge_number"] == 12
+
+
+def test_parse_tab_sheet_speakers():
+    """Speaker rows parse names, per-round scores, totals, and placement."""
+    result = parse_tab_sheet_from_html(SAMPLE_HTML)
+    comp = result["competitors"][0]
+
+    assert len(comp["speakers"]) == 2
+
+    s1 = comp["speakers"][0]
+    assert s1["name"] == JOSH_LYMAN
+    assert s1["round_scores"] == [29.0, 28.5]
+    assert s1["total_points"] == 57.5
+    assert s1["placement"] == "3rd"
+
+    s2 = comp["speakers"][1]
+    assert s2["name"] == SAM_SEABORN
+    assert s2["round_scores"] == [28.5, 27.5]
+    assert s2["total_points"] == 56.0
+    assert s2["placement"] == "8th"
+
+
+def test_parse_tab_sheet_bye_round():
+    """BYE round is parsed correctly with no opponent/side/judge."""
+    result = parse_tab_sheet_from_html(SAMPLE_HTML)
+    comp = result["competitors"][1]
+
+    r2 = comp["rounds"][1]
+    assert r2["result"] == "BYE"
+    assert r2["opponent"] is None
+    assert r2["side"] is None
+    assert r2["judge"] is None
+
+
+def test_parse_tab_sheet_loss():
+    """L result parses correctly with opponent and judge details."""
+    result = parse_tab_sheet_from_html(SAMPLE_HTML)
+    comp = result["competitors"][1]
+
+    r1 = comp["rounds"][0]
+    assert r1["result"] == "L"
+    assert r1["opponent"] == f"{MANCHESTER_PREP} BALY"
+    assert r1["judge"] == JED_BARTLET
+
+
+def test_parse_tab_sheet_forfeit():
+    """FORFEIT round is parsed correctly."""
+    html = _build_tab_sheet_html(
+        grouping_name="JV Lincoln-Douglas",
+        round_names=["Round 1", "Round 2"],
+        competitor_blocks=[
+            _team_row(
+                comp_id=77,
+                name=f"{HARTSFIELD_LANDING} DOYO",
+                round_cells=[
+                    _win_cell(f"{MANCHESTER_PREP} BALY", "AFF", 3, DONNA_MOSS),
+                    _forfeit_cell(),
+                ],
+                record="1-1",
+                total_points="55.0",
+                placement="10th",
+            ),
+            _speaker_row(CHARLIE_YOUNG, ["28.00", "&nbsp;"], "28.00", "20th"),
+        ],
+    )
+    result = parse_tab_sheet_from_html(html)
+    comp = result["competitors"][0]
+
+    r2 = comp["rounds"][1]
+    assert r2["result"] == "FORFEIT"
+    assert r2["opponent"] is None
+
+    # Speaker with empty round score
+    spk = comp["speakers"][0]
+    assert spk["round_scores"][1] is None
+
+
+def test_parse_tab_sheet_empty_round_cell():
+    """Empty round cell (no result at all) returns None for all fields."""
+    html = _build_tab_sheet_html(
+        grouping_name="Novice Debate",
+        round_names=["Round 1", "Round 2"],
+        competitor_blocks=[
+            _team_row(
+                comp_id=50,
+                name=f"{ROSSLYN_ACADEMY} HABA",
+                round_cells=[
+                    _win_cell(f"{MANCHESTER_PREP} BALY", "Neg", 1, DONNA_MOSS),
+                    _empty_cell(),
+                ],
+                record="1-0",
+                total_points="55.0",
+                placement="15th",
+            ),
+            _speaker_row(JOSH_LYMAN, ["28.00", "&nbsp;"], "28.00", "30th"),
+        ],
+    )
+    result = parse_tab_sheet_from_html(html)
+    comp = result["competitors"][0]
+
+    r2 = comp["rounds"][1]
+    assert r2["result"] is None
+    assert r2["opponent"] is None
+
+
+def test_parse_tab_sheet_three_rounds():
+    """Parser handles three-round tournaments correctly."""
+    html = _build_tab_sheet_html(
+        grouping_name="Varsity Policy Debate",
+        round_names=["Round 1", "Round 2", "Round 3"],
+        competitor_blocks=[
+            _team_row(
+                comp_id=10,
+                name=f"{MANCHESTER_PREP} BALY",
+                round_cells=[
+                    _win_cell(f"{ROSSLYN_ACADEMY} LYSE", "AFF", 1, JED_BARTLET),
+                    _loss_cell(f"{HARTSFIELD_LANDING} CRYO", "Neg", 2, LEO_MCGARRY),
+                    _bye_cell(),
+                ],
+                record="2-1",
+                total_points="165.0",
+                placement="3rd",
+            ),
+            _speaker_row(JOSH_LYMAN, ["29.00", "27.00", "28.00"], "84.00", "5th"),
+            _speaker_row(SAM_SEABORN, ["28.00", "26.00", "27.00"], "81.00", "10th"),
+        ],
+    )
+    result = parse_tab_sheet_from_html(html)
+
+    assert result["round_names"] == ["Round 1", "Round 2", "Round 3"]
+    comp = result["competitors"][0]
+    assert len(comp["rounds"]) == 3
+    assert comp["rounds"][0]["result"] == "W"
+    assert comp["rounds"][1]["result"] == "L"
+    assert comp["rounds"][2]["result"] == "BYE"
+
+    assert len(comp["speakers"]) == 2
+    assert comp["speakers"][0]["round_scores"] == [29.0, 27.0, 28.0]
+
+
+def test_parse_tab_sheet_empty_html():
+    """Empty HTML returns empty structure."""
+    result = parse_tab_sheet_from_html("")
+    assert result["grouping_name"] == ""
+    assert result["round_names"] == []
+    assert result["competitors"] == []
+
+
+def test_parse_tab_sheet_no_table():
+    """HTML without a results table returns empty competitors."""
+    html = "<html><body><p>Nothing here</p></body></html>"
+    result = parse_tab_sheet_from_html(html)
+    assert result["competitors"] == []
+
+
+def test_parse_tab_sheet_real_page_structure():
+    """Parser handles the full page structure from the actual SpeechWire site."""
+    # Minimal reproduction of the real page structure with wrapper elements
+    html = (
+        "<!DOCTYPE html><html><head><title>SpeechWire</title></head><body>"
+        "<p class='pagetitle'>Grouping tab sheet</p>"
+        "<form name='form1' method='get' action='tab-grouping.php'>"
+        "<select id='groupingid' name='groupingid'>"
+        "<option selected value='4'>Novice Debate</option>"
+        "</select></form>"
+        "<p><span class='pagesubtitle'>Novice Debate</span></p>"
+        "<table class='dd'>"
+        "<tr class='tableheader'>"
+        "<td class='dd centered'>Competitor</td>"
+        "<td class='dd centered'>Round 1</td>"
+        "<td class='dd centered'>Totals</td>"
+        "<td class='dd centered'>Results</td>"
+        "</tr>"
+        "<tr><td class='dd centered'><strong>"
+        f"<a href='view-comp.php?compid=100'>{MANCHESTER_PREP} BALY</a>"
+        "</strong></td>"
+        "<td class='dd centered'><strong>BYE</strong>&nbsp;</td>"
+        "<td rowspan='1' class='dd centered'><strong>1-0</strong>"
+        "<br /><span style='font-size: 10px;'>56.0</span></td>"
+        "<td rowspan='1' class='dd centered'><strong>1st</strong></td>"
+        "</tr>"
+        f"<tr><td class='dd centered'>{JOSH_LYMAN}</td>"
+        "<td class='dd centered'>28.00</td>"
+        "<td class='dd centered'>28.00</td>"
+        "<td class='dd centered'>1st</td></tr>"
+        "</table>"
+        "</body></html>"
+    )
+    result = parse_tab_sheet_from_html(html)
+
+    assert result["grouping_name"] == "Novice Debate"
+    assert result["round_names"] == ["Round 1"]
+    assert len(result["competitors"]) == 1
+
+    comp = result["competitors"][0]
+    assert comp["comp_id"] == 100
+    assert comp["record"] == "1-0"
+    assert comp["total_points"] == 56.0
+    assert comp["placement"] == "1st"
+    assert comp["rounds"][0]["result"] == "BYE"
+    assert comp["speakers"][0]["name"] == JOSH_LYMAN


### PR DESCRIPTION
## Summary

Add a new `results/` domain module that parses tournament results (tab sheets) from `tab-grouping.php` pages.

### New MCP Tool

**`speechwire_get_tab_sheet(grouping_id)`** — fetches and parses the results tab sheet for a competition grouping, returning:

- Grouping name and round column headers
- Per-competitor: comp_id, team name, win/loss record, total points, placement
- Per-round: result (W/L/BYE/FORFEIT), opponent, side (AFF/Neg), judge name & number
- Per-speaker: name, round-by-round scores, total points, speaker placement

### Files Changed

| File | Description |
|------|-------------|
| `src/speechwire_mcp/results/parsers.py` | Pure parser: `parse_tab_sheet_from_html()` |
| `src/speechwire_mcp/results/client.py` | HTTP retrieval via `_fetch_and_parse` |
| `src/speechwire_mcp/results/__init__.py` | Module exports |
| `src/speechwire_mcp/server.py` | `speechwire_get_tab_sheet` tool registration |
| `src/speechwire_mcp/__init__.py` | Package-level export |
| `tests/test_results_parsers.py` | 12 unit tests |

### Testing

- **12 new tests** covering: happy path, W/L/BYE/FORFEIT results, empty cells, multi-round, empty HTML, no table, and real page structure
- All **210 tests pass**, lint clean
