### PR TITLE
Fix critical issues from squad codebase review

### DIFF
--- a/src/speechwire_mcp/client.py
+++ b/src/speechwire_mcp/client.py
@@ -314,8 +314,12 @@ class SpeechWireClient:
             Form data to submit.
         """
         resp = self.session.post(url, data=data)
-        if self._looks_like_expired_session(resp):
-            self._authenticate()
+        if self._looks_like_expired_session(resp) and not self._reauthenticating:
+            self._reauthenticating = True
+            try:
+                self._authenticate()
+            finally:
+                self._reauthenticating = False
             resp = self.session.post(url, data=data)
         return resp
 

--- a/src/speechwire_mcp/judges/parsers.py
+++ b/src/speechwire_mcp/judges/parsers.py
@@ -107,7 +107,7 @@ def parse_judge_list_from_html(html: str) -> List[Dict]:
         if blocks_td:
             raw = blocks_td.decode_contents().strip()
             if raw and raw != "&nbsp;":
-                blocks = [b.strip() for b in raw.split("<br/>") if b.strip()]
+                blocks = [b.strip() for b in re.split(r"<br\s*/?>", raw, flags=re.IGNORECASE) if b.strip()]
 
         records.append(
             {

--- a/src/speechwire_mcp/schematics/parsers.py
+++ b/src/speechwire_mcp/schematics/parsers.py
@@ -92,7 +92,7 @@ def parse_round_schematic_html(html: str) -> dict:
     time = None
     header_text = header_tds[0].get_text(strip=True)
     # Format: "Event Name Round N - Time"
-    parts = header_text.split(" Round ")
+    parts = header_text.rsplit(" Round ", 1)
     if len(parts) == 2:
         event_name = parts[0].strip()
         round_and_time = parts[1].split(" - ")


### PR DESCRIPTION
## Summary

Fixes three critical issues identified during the squad codebase review (Leo, Charlie, Ainsley).

### Changes

**1. Fix judge blocks `<br>` splitting** — `judges/parsers.py`
The blocks column parser split on `<br/>` only. HTML variants like `<br>`, `<br />`, and `<BR>` were silently merging block entries into a single string. Replaced with `re.split(r"<br\s*/?>", ...)` to handle all variants — the same pattern already used in `teams/parsers.py`.

**2. Fix schematic event name parsing** — `schematics/parsers.py`
`header_text.split(" Round ")` split on the *first* occurrence of " Round ", so event names containing that substring (e.g. "Pre-Round Debate") were truncated. Changed to `rsplit(" Round ", 1)` to split on the last occurrence.

**3. Add re-auth recursion guard to `post()`** — `client.py`
`get()` already has a `_reauthenticating` flag to prevent infinite re-auth loops, but `post()` lacked the same guard. Added the identical pattern to prevent potential stack overflow if `_authenticate()` ever issues a POST to a page that triggers re-auth.

### Testing

All 210 existing tests pass. Ruff clean.