### PR TITLE
Address squad review improvement findings

### DIFF
--- a/src/speechwire_mcp/client.py
+++ b/src/speechwire_mcp/client.py
@@ -110,7 +110,7 @@ class SpeechWireClient:
                     "Login rejected — SpeechWire reported invalid credentials"
                 )
             self.state = ClientState.LOGGED_IN
-            logger.info("Logged in as %s", self.email)
+            logger.debug("Logged in as %s", self.email)
         except RequestException as e:
             raise SpeechWireAuthError(f"Login failed: {e}") from e
 
@@ -126,7 +126,8 @@ class SpeechWireClient:
         """
         try:
             resp = self.session.get(
-                f"https://www.speechwire.com/c-account-select.php?selectaccountid={account_id}"
+                "https://www.speechwire.com/c-account-select.php",
+                params={"selectaccountid": str(account_id)},
             )
             resp.raise_for_status()
             self.account_id = str(account_id)
@@ -282,7 +283,7 @@ class SpeechWireClient:
             return True
         return False
 
-    def get(self, url: str) -> requests.Response:
+    def get(self, url: str, params: dict | None = None) -> requests.Response:
         """GET a manage.speechwire.com page with session-expiry handling.
 
         If the response looks like an expired session (login page redirect
@@ -290,14 +291,14 @@ class SpeechWireClient:
         and retries the request once.  A guard prevents infinite recursion
         when ``_authenticate`` itself issues GETs (e.g. account discovery).
         """
-        resp = self.session.get(url)
+        resp = self.session.get(url, params=params)
         if self._looks_like_expired_session(resp) and not self._reauthenticating:
             self._reauthenticating = True
             try:
                 self._authenticate()
             finally:
                 self._reauthenticating = False
-            resp = self.session.get(url)
+            resp = self.session.get(url, params=params)
         return resp
 
     def post(self, url: str, data: dict) -> requests.Response:
@@ -330,6 +331,7 @@ def _fetch_and_parse(
     parser: Callable[[str], T],
     default: T,
     context: str = "",
+    params: dict | None = None,
 ) -> T:
     """Fetch a page and parse it, returning *default* on any failure.
 
@@ -345,22 +347,24 @@ def _fetch_and_parse(
         Value returned when fetching or parsing fails.
     context : str
         Human-readable label for log messages.
+    params : dict | None
+        Optional query parameters passed to ``requests.Session.get``.
     """
     if not client:
         logger.error("No SpeechWire client provided")
         return default
 
     try:
-        resp = client.get(url)
+        resp = client.get(url, params=params)
         resp.raise_for_status()
     except Exception:
-        logger.exception("Failed to fetch %s", context)
+        logger.error("Failed to fetch %s", context)
         return default
 
     try:
         return parser(resp.text)
     except Exception:
-        logger.exception("Failed to parse %s", context)
+        logger.error("Failed to parse %s", context)
         return default
 
 
@@ -397,11 +401,11 @@ def _post_and_parse(
         resp = client.post(url, data=data)
         resp.raise_for_status()
     except Exception:
-        logger.exception("Failed to post %s", context)
+        logger.error("Failed to post %s", context)
         return default
 
     try:
         return parser(resp.text)
     except Exception:
-        logger.exception("Failed to parse %s response", context)
+        logger.error("Failed to parse %s response", context)
         return default

--- a/src/speechwire_mcp/judges/client.py
+++ b/src/speechwire_mcp/judges/client.py
@@ -1,4 +1,3 @@
-from typing import List, Dict
 import logging
 
 from speechwire_mcp.client import SpeechWireClient, _fetch_and_parse, _post_and_parse
@@ -14,13 +13,13 @@ from speechwire_mcp.judges.parsers import (
 logger = logging.getLogger(__name__)
 
 
-def get_judge_list(client: SpeechWireClient) -> List[Dict]:
+def get_judge_list(client: SpeechWireClient) -> list[dict]:
     """Retrieve judge list with roster details from the dashboard."""
 
     # Local _parse wrapper filters out records with None judge_id (business logic,
     # not parsing) — this pattern is used when post-processing is needed after
     # HTML parsing. See get_judge_availability for comparison (no wrapper needed).
-    def _parse(html: str) -> List[Dict]:
+    def _parse(html: str) -> list[dict]:
         records = parse_judge_list_from_html(html)
         return [r for r in records if r.get("judge_id") is not None]
 
@@ -33,7 +32,7 @@ def get_judge_list(client: SpeechWireClient) -> List[Dict]:
     )
 
 
-def get_judge_contact(judge_id: int, client: SpeechWireClient) -> Dict:
+def get_judge_contact(judge_id: int, client: SpeechWireClient) -> dict:
     """Fetch judge edit page and return contact information.
 
     Returns a dict with judge_id, email, phone.
@@ -41,7 +40,7 @@ def get_judge_contact(judge_id: int, client: SpeechWireClient) -> Dict:
 
     # Local _parse wrapper injects the judge_id parameter into the result (business
     # logic, not parsing). The parser only extracts email/phone from HTML.
-    def _parse(html: str) -> Dict:
+    def _parse(html: str) -> dict:
         parsed = parse_judge_edit_contact_html(html)
         return {
             "judge_id": judge_id,
@@ -51,7 +50,7 @@ def get_judge_contact(judge_id: int, client: SpeechWireClient) -> Dict:
 
     return _fetch_and_parse(
         client,
-        f"https://manage.speechwire.com/tabroom/view-judge.php?judgeid={judge_id}",
+        "https://manage.speechwire.com/tabroom/view-judge.php",
         _parse,
         default={
             "judge_id": judge_id,
@@ -59,27 +58,29 @@ def get_judge_contact(judge_id: int, client: SpeechWireClient) -> Dict:
             "phone": None,
         },
         context=f"judge contact for {judge_id}",
+        params={"judgeid": str(judge_id)},
     )
 
 
-def get_judge_availability(judge_id: int, client: SpeechWireClient) -> List[Dict]:
+def get_judge_availability(judge_id: int, client: SpeechWireClient) -> list[dict]:
     """Fetch and parse a judge's availability from their edit page."""
     return _fetch_and_parse(
         client,
-        f"https://manage.speechwire.com/tabroom/judges-edit.php?judgeid={judge_id}",
+        "https://manage.speechwire.com/tabroom/judges-edit.php",
         parse_availability_from_edit_html,
         default=[],
         context=f"availability for {judge_id}",
+        params={"judgeid": str(judge_id)},
     )
 
 
-def get_judge_school(judge_id: int, client: SpeechWireClient) -> Dict:
+def get_judge_school(judge_id: int, client: SpeechWireClient) -> dict:
     """Fetch judge edit page and return school association.
 
     Returns a dict with judge_id, school, and team_id.
     """
 
-    def _parse(html: str) -> Dict:
+    def _parse(html: str) -> dict:
         parsed = parse_school_from_edit_html(html)
         return {
             "judge_id": judge_id,
@@ -89,7 +90,7 @@ def get_judge_school(judge_id: int, client: SpeechWireClient) -> Dict:
 
     return _fetch_and_parse(
         client,
-        f"https://manage.speechwire.com/tabroom/judges-edit.php?judgeid={judge_id}",
+        "https://manage.speechwire.com/tabroom/judges-edit.php",
         _parse,
         default={
             "judge_id": judge_id,
@@ -97,6 +98,7 @@ def get_judge_school(judge_id: int, client: SpeechWireClient) -> Dict:
             "team_id": None,
         },
         context=f"school for {judge_id}",
+        params={"judgeid": str(judge_id)},
     )
 
 
@@ -110,7 +112,7 @@ def add_judge(
     is_coach: bool = False,
     is_priority: bool = False,
     available_slots: list[int] | None = None,
-) -> Dict:
+) -> dict:
     """Add a new judge to the active tournament.
 
     Parameters
@@ -185,7 +187,7 @@ def add_judge(
     )
 
 
-def get_judge_types(client: SpeechWireClient) -> List[Dict]:
+def get_judge_types(client: SpeechWireClient) -> list[dict]:
     """Fetch and parse the judge types for the active tournament.
 
     Parameters

--- a/src/speechwire_mcp/judges/parsers.py
+++ b/src/speechwire_mcp/judges/parsers.py
@@ -1,4 +1,3 @@
-from typing import Optional, List, Dict
 import logging
 import re
 from bs4 import element
@@ -10,7 +9,7 @@ logger = logging.getLogger(__name__)
 _EMAIL_RE = re.compile(r"[\w\.-]+@[\w\.-]+\.\w+", re.IGNORECASE)
 
 
-def _selected_value(td: Optional[element.Tag], select_name_prefix: str) -> Optional[str]:
+def _selected_value(td: element.Tag | None, select_name_prefix: str) -> str | None:
     """Return the selected <option> value from a <select> inside a <td>."""
     if td is None:
         return None
@@ -21,7 +20,7 @@ def _selected_value(td: Optional[element.Tag], select_name_prefix: str) -> Optio
     return option.get("value") if option else None
 
 
-def parse_judge_list_from_html(html: str) -> List[Dict]:
+def parse_judge_list_from_html(html: str) -> list[dict]:
     """Parse SpeechWire judge dashboard HTML into structured judge records.
 
     The dashboard sometimes marks judges with a ``(Coach)`` indicator next
@@ -39,7 +38,7 @@ def parse_judge_list_from_html(html: str) -> List[Dict]:
     if table is None:
         return []
 
-    records: List[Dict] = []
+    records: list[dict] = []
 
     for tr in table.find_all("tr"):
         if "tableheader" in (tr.get("class") or []):
@@ -50,8 +49,8 @@ def parse_judge_list_from_html(html: str) -> List[Dict]:
             continue
 
         # Col 0: Name + judge_id + optional (Coach) indicator
-        name = None
-        judge_id: Optional[int] = None
+        name: str | None = None
+        judge_id: int | None = None
         is_coach = False
         name_td = td_safe(tds, 0)
         if name_td:
@@ -64,8 +63,8 @@ def parse_judge_list_from_html(html: str) -> List[Dict]:
                 is_coach = True
 
         # Col 1: Team name + team_id
-        team: Optional[str] = None
-        team_id: Optional[int] = None
+        team: str | None = None
+        team_id: int | None = None
         team_td = td_safe(tds, 1)
         if team_td:
             team_link = team_td.find("a")
@@ -95,14 +94,14 @@ def parse_judge_list_from_html(html: str) -> List[Dict]:
 
         # Col 8: Unavailability text
         unavail_td = td_safe(tds, 8)
-        unavailability: Optional[str] = None
+        unavailability: str | None = None
         if unavail_td:
             text = unavail_td.get_text(strip=True)
             if text:
                 unavailability = text
 
         # Col 10: Blocks (e.g. "GROUPING: Varsity Policy Debate")
-        blocks: List[str] = []
+        blocks: list[str] = []
         blocks_td = td_safe(tds, 10)
         if blocks_td:
             raw = blocks_td.decode_contents().strip()
@@ -128,7 +127,7 @@ def parse_judge_list_from_html(html: str) -> List[Dict]:
     return records
 
 
-def parse_availability_from_edit_html(html: str) -> List[Dict]:
+def parse_availability_from_edit_html(html: str) -> list[dict]:
     """Parse the 'Availability by timeslot' table from a judge edit HTML page."""
     soup = make_soup(html)
 
@@ -145,13 +144,13 @@ def parse_availability_from_edit_html(html: str) -> List[Dict]:
         return []
 
     header = table.find("tr", class_="tableheader")
-    labels: List[str] = []
+    labels: list[str] = []
     if header:
         header_tds = header.find_all("td")
         labels = [td.get_text(" ", strip=True) for td in header_tds]
 
     inputs = table.find_all("input", {"type": "checkbox"})
-    availability: List[Dict] = []
+    availability: list[dict] = []
     idx = 0
     for inp in inputs:
         name = inp.get("name", "") or ""
@@ -170,7 +169,7 @@ def parse_availability_from_edit_html(html: str) -> List[Dict]:
     return availability
 
 
-def parse_phone_from_edit_html(html: str) -> Optional[str]:
+def parse_phone_from_edit_html(html: str) -> str | None:
     """Extract the cell phone text from a judge edit HTML page."""
     if not html:
         return None
@@ -180,14 +179,14 @@ def parse_phone_from_edit_html(html: str) -> Optional[str]:
     return m.group(1).strip()
 
 
-def parse_judge_edit_contact_html(html: str) -> Dict:
+def parse_judge_edit_contact_html(html: str) -> dict:
     """Extract email and phone from a judge edit page HTML.
 
     Returns dict with keys: email, phone.
     """
     soup = make_soup(html)
 
-    def _valid_email(val: Optional[str]) -> Optional[str]:
+    def _valid_email(val: str | None) -> str | None:
         if not val:
             return None
         val = val.strip()
@@ -196,7 +195,7 @@ def parse_judge_edit_contact_html(html: str) -> Dict:
         return val.lower()
 
     # 1) Prefer explicit judgeemail input value
-    email_val: Optional[str] = None
+    email_val: str | None = None
     email_input = soup.find("input", {"id": "judgeemail"}) or soup.find(
         "input", {"name": "judgeemail"}
     )
@@ -224,7 +223,7 @@ def parse_judge_edit_contact_html(html: str) -> Dict:
     }
 
 
-def parse_school_from_edit_html(html: str) -> Dict:
+def parse_school_from_edit_html(html: str) -> dict:
     """Extract the judge's school (team) association from a judge edit page.
 
     The school is determined by the selected ``<option>`` in the
@@ -257,7 +256,7 @@ def parse_school_from_edit_html(html: str) -> Dict:
     return {"school": school, "team_id": team_id}
 
 
-def parse_add_judge_response(html: str) -> Dict:
+def parse_add_judge_response(html: str) -> dict:
     """Parse the response from a judge-creation POST.
 
     Determines whether the judge was successfully created by looking for
@@ -278,7 +277,7 @@ def parse_add_judge_response(html: str) -> Dict:
 
     # --- error signals ---
     mode_input = soup.find("input", {"name": "mode", "value": "addjudge"})
-    error_texts: List[str] = []
+    error_texts: list[str] = []
     for tag in soup.find_all(["p", "div"]):
         text = tag.get_text(" ", strip=True)
         if text and "error" in text.lower():
@@ -288,7 +287,7 @@ def parse_add_judge_response(html: str) -> Dict:
     has_error = bool(mode_input) or bool(error_texts) or no_judge
 
     # --- success signals ---
-    judge_id: Optional[int] = None
+    judge_id: int | None = None
     success_msg = soup.find("div", class_="successmsg")
 
     # Extract judge_id from hidden input or links
@@ -312,8 +311,8 @@ def parse_add_judge_response(html: str) -> Dict:
         success_msg is not None
         or judge_id is not None
         or "judge added" in body_text
-        or "added" in body_text
-        or "saved" in body_text
+        or "judge saved" in body_text
+        or "successfully" in body_text
     )
 
     # --- priority: error overrides success ---
@@ -327,11 +326,11 @@ def parse_add_judge_response(html: str) -> Dict:
     if has_success:
         return {"success": True, "judge_id": judge_id, "error": None}
 
-    # ambiguous 200 — assume success
-    return {"success": True, "judge_id": None, "error": None}
+    # ambiguous 200 — no clear success or error signals
+    return {"success": False, "judge_id": None, "error": "ambiguous response (no success signal)"}
 
 
-def parse_judge_types_from_html(html: str) -> List[Dict]:
+def parse_judge_types_from_html(html: str) -> list[dict]:
     """Parse the judge types list page into structured records.
 
     Parameters
@@ -350,7 +349,7 @@ def parse_judge_types_from_html(html: str) -> List[Dict]:
     if table is None:
         return []
 
-    records: List[Dict] = []
+    records: list[dict] = []
 
     for tr in table.find_all("tr"):
         if "tableheader" in (tr.get("class") or []):
@@ -362,8 +361,8 @@ def parse_judge_types_from_html(html: str) -> List[Dict]:
 
         # Col 0: judge type name + judge_type_id from link
         name_td = td_safe(tds, 0)
-        judge_type_id: Optional[int] = None
-        judge_type: Optional[str] = None
+        judge_type_id: int | None = None
+        judge_type: str | None = None
         if name_td:
             link = name_td.find("a")
             if link:
@@ -375,7 +374,7 @@ def parse_judge_types_from_html(html: str) -> List[Dict]:
 
         # Col 1: comma-separated grouping codes
         groupings_td = td_safe(tds, 1)
-        groupings: List[str] = []
+        groupings: list[str] = []
         if groupings_td:
             raw = groupings_td.get_text(strip=True)
             groupings = [g.strip() for g in raw.split(",") if g.strip()]

--- a/src/speechwire_mcp/results/client.py
+++ b/src/speechwire_mcp/results/client.py
@@ -31,11 +31,18 @@ def get_tab_sheet(grouping_id: int, client: SpeechWireClient) -> dict:
         and ``competitors`` with round-by-round outcomes, speaker
         scores, and placements.
     """
-    url = f"{_BASE}?groupingid={grouping_id}&Submit=View+tab+sheet&sortby=&divisionrestrict="
+    url = f"{_BASE}"
+    params = {
+        "groupingid": str(grouping_id),
+        "Submit": "View tab sheet",
+        "sortby": "",
+        "divisionrestrict": "",
+    }
     return _fetch_and_parse(
         client,
         url,
         parse_tab_sheet_from_html,
         default={},
         context=f"tab sheet for grouping {grouping_id}",
+        params=params,
     )

--- a/src/speechwire_mcp/schematics/client.py
+++ b/src/speechwire_mcp/schematics/client.py
@@ -1,8 +1,12 @@
+import logging
+
 from speechwire_mcp.client import SpeechWireClient, _fetch_and_parse
 from speechwire_mcp.schematics.parsers import (
     parse_schematic_events_html,
     parse_round_schematic_html,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def get_schematic_events(client: SpeechWireClient) -> list[dict]:
@@ -35,14 +39,11 @@ def get_round_schematic(
     dict
         Round schematic with event name, time, unused judges, and sections.
     """
-    url = (
-        f"https://manage.speechwire.com/tabroom/schem-edit.php"
-        f"?groupingid={grouping_id}&round={round_number}"
-    )
     return _fetch_and_parse(
         client,
-        url,
+        "https://manage.speechwire.com/tabroom/schem-edit.php",
         parse_round_schematic_html,
         default={},
         context=f"round schematic for grouping {grouping_id} round {round_number}",
+        params={"groupingid": str(grouping_id), "round": str(round_number)},
     )

--- a/src/speechwire_mcp/schematics/parsers.py
+++ b/src/speechwire_mcp/schematics/parsers.py
@@ -8,6 +8,41 @@ from speechwire_mcp.parsing_helpers import make_soup, td_safe, extract_int_query
 logger = logging.getLogger(__name__)
 
 
+def _parse_judge_from_link(link) -> dict | None:
+    """Extract judge info from an anchor tag with "Name [N]" format.
+
+    Parameters
+    ----------
+    link : bs4.element.Tag
+        Anchor tag with ``firstjudgeid`` query param.
+
+    Returns
+    -------
+    dict | None
+        ``{"judge_id": int, "name": str, "rounds_judged": int | None}``
+        or None if judge_id cannot be extracted.
+    """
+    judge_id = extract_int_query_param(link, "firstjudgeid")
+    if judge_id is None:
+        return None
+    text = link.get_text(strip=True)
+    name = None
+    rounds_judged = None
+    if "[" in text and "]" in text:
+        parts = text.rsplit("[", 1)
+        name = parts[0].strip()
+        try:
+            rounds_judged = int(parts[1].rstrip("]").strip())
+        except ValueError:
+            pass
+    else:
+        name = text
+    return {"judge_id": judge_id, "name": name, "rounds_judged": rounds_judged}
+
+
+_SIDE_RE = re.compile(r"\((?:aff|neg)\)", re.IGNORECASE)
+
+
 def parse_schematic_events_html(html: str) -> list[dict]:
     """Parse schematic events from the schematic viewer page.
 
@@ -109,28 +144,9 @@ def parse_round_schematic_html(html: str) -> dict:
     unused_cell = header_tds[1]
     unused_links = unused_cell.find_all("a", href=lambda h: h and "firstjudgeid=" in h)
     for link in unused_links:
-        judge_id = extract_int_query_param(link, "firstjudgeid")
-        if judge_id is None:
-            continue
-        # Parse "Name [N]" format
-        text = link.get_text(strip=True)
-        name = None
-        rounds_judged = None
-        if "[" in text and "]" in text:
-            parts = text.rsplit("[", 1)
-            name = parts[0].strip()
-            try:
-                rounds_judged = int(parts[1].rstrip("]").strip())
-            except ValueError:
-                pass
-        else:
-            name = text
-
-        unused_judges.append({
-            "judge_id": judge_id,
-            "name": name,
-            "rounds_judged": rounds_judged,
-        })
+        judge = _parse_judge_from_link(link)
+        if judge:
+            unused_judges.append(judge)
 
     # Skip row 1 (column labels)
     # Parse data rows (rows 2+)
@@ -156,25 +172,7 @@ def parse_round_schematic_html(html: str) -> dict:
         if judge_td:
             judge_link = judge_td.find("a", href=lambda h: h and "firstjudgeid=" in h)
             if judge_link:
-                judge_id = extract_int_query_param(judge_link, "firstjudgeid")
-                text = judge_link.get_text(strip=True)
-                name = None
-                rounds_judged = None
-                if "[" in text and "]" in text:
-                    parts = text.rsplit("[", 1)
-                    name = parts[0].strip()
-                    try:
-                        rounds_judged = int(parts[1].rstrip("]").strip())
-                    except ValueError:
-                        pass
-                else:
-                    name = text
-                if judge_id is not None:
-                    judge = {
-                        "judge_id": judge_id,
-                        "name": name,
-                        "rounds_judged": rounds_judged,
-                    }
+                judge = _parse_judge_from_link(judge_link)
 
         # Cell 2: room
         room_td = td_safe(tds, 2)
@@ -205,15 +203,13 @@ def parse_round_schematic_html(html: str) -> dict:
             side = None
             record = None
 
-            # Extract side (AFF or Neg)
-            if "(AFF)" in text or "(Aff)" in text:
-                side = "AFF"
-            elif "(NEG)" in text or "(Neg)" in text:
-                side = "Neg"
+            # Extract side (AFF or NEG), case-insensitive
+            side_match = _SIDE_RE.search(text)
+            if side_match:
+                side = side_match.group(0)[1:-1].upper()
 
             # Remove side markers to get name and record
-            clean_text = text.replace("(AFF)", "").replace("(Aff)", "")
-            clean_text = clean_text.replace("(NEG)", "").replace("(Neg)", "")
+            clean_text = _SIDE_RE.sub("", text)
 
             # Find record pattern (W-L)
             record_match = re.search(r"\((\d+-\d+)\)", clean_text)

--- a/src/speechwire_mcp/server.py
+++ b/src/speechwire_mcp/server.py
@@ -704,7 +704,7 @@ def main():
     transport = os.environ.get("SPEECHWIRE_MCP_TRANSPORT", "stdio").lower()
 
     if transport == "sse":
-        host = os.environ.get("SPEECHWIRE_MCP_HOST", "0.0.0.0")
+        host = os.environ.get("SPEECHWIRE_MCP_HOST", "127.0.0.1")
         port = int(os.environ.get("SPEECHWIRE_MCP_PORT", "8080"))
         logger.info("Starting SpeechWire MCP server (SSE) on %s:%d", host, port)
         mcp.run(transport="sse", host=host, port=port)

--- a/src/speechwire_mcp/teams/client.py
+++ b/src/speechwire_mcp/teams/client.py
@@ -1,9 +1,13 @@
+import logging
+
 from speechwire_mcp.client import SpeechWireClient, _fetch_and_parse
 from speechwire_mcp.teams.parsers import (
     parse_team_list_html,
     parse_team_entries_html,
     parse_hybrid_entries_html,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def get_team_list(client: SpeechWireClient) -> list[dict]:
@@ -52,10 +56,11 @@ def get_team_entries(team_id: int, client: SpeechWireClient) -> list[dict]:
     """
     return _fetch_and_parse(
         client,
-        f"https://manage.speechwire.com/tabroom/teams-entries.php?teamid={team_id}",
+        "https://manage.speechwire.com/tabroom/teams-entries.php",
         parse_team_entries_html,
         default=[],
         context=f"entries for team {team_id}",
+        params={"teamid": str(team_id)},
     )
 
 

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -553,10 +553,10 @@ class TestParseAddJudgeResponse:
         result = parse(ADD_JUDGE_FORM_RERENDERED_HTML)
         assert result["success"] is False
 
-    def test_empty_html_assumes_success(self):
+    def test_empty_html_returns_failure(self):
         parse = _import_parse_add_judge_response()
         result = parse("")
-        assert result["success"] is True
+        assert result["success"] is False
         assert result["judge_id"] is None
 
     def test_judge_list_rendered_is_success(self):

--- a/tests/test_schematics_parsers.py
+++ b/tests/test_schematics_parsers.py
@@ -209,7 +209,7 @@ def test_parse_round_schematic_happy_path():
     assert section_a["competitors"][0]["record"] == "2-0"
     assert section_a["competitors"][1]["competitor_id"] == 184
     assert section_a["competitors"][1]["name"] == CHARLIE_YOUNG
-    assert section_a["competitors"][1]["side"] == "Neg"
+    assert section_a["competitors"][1]["side"] == "NEG"
     assert section_a["competitors"][1]["record"] == "1-1"
     
     # Section B
@@ -225,7 +225,7 @@ def test_parse_round_schematic_happy_path():
     assert section_b["competitors"][0]["record"] == "1-1"
     assert section_b["competitors"][1]["competitor_id"] == 186
     assert section_b["competitors"][1]["name"] == WILL_BAILEY
-    assert section_b["competitors"][1]["side"] == "Neg"
+    assert section_b["competitors"][1]["side"] == "NEG"
     assert section_b["competitors"][1]["record"] == "0-2"
 
 


### PR DESCRIPTION
## Summary

Addresses the "Fix Soon" issues from the squad codebase review (Leo, Charlie, Ainsley).

### Security Improvements
- **Default SSE bind to `127.0.0.1`** instead of `0.0.0.0` — prevents exposing MCP tools to the network without auth/TLS
- **Redact user email from logs** — downgraded login email from INFO to DEBUG level
- **Use `requests` params dict** instead of f-string URL interpolation across all client modules (`judges/`, `schematics/`, `teams/`, `results/`, `client.py`)
- **Replace `logger.exception` with `logger.error`** in `_fetch_and_parse`/`_post_and_parse` to prevent leaking URLs/cookies in stack traces

### Code Quality
- **Modernize `judges/` typing** — replaced ~30 instances of `typing.List`/`Dict`/`Optional` with builtin generics (`list[dict]`, `str | None`)
- **Extract `_parse_judge_from_link()` helper** in `schematics/parsers.py` — eliminates duplicated judge-link parsing logic
- **Add missing loggers** to `schematics/client.py` and `teams/client.py`

### Parser Accuracy
- **Tighten `add_judge` success heuristic** — narrowed from `"added" in body_text` to `"judge added"`/`"judge saved"`/`"successfully"`; ambiguous-200 now returns failure instead of assuming success
- **Case-insensitive side detection** — replaced hardcoded 4-variant check with `re.compile(r"\((?:aff|neg)\)", re.IGNORECASE)`; side values now consistently uppercase (`AFF`/`NEG`)

### Testing
All 210 tests pass. Tests updated for:
- New side normalization (`NEG` instead of `Neg`)
- Stricter add_judge ambiguous-200 behavior