### PR TITLE
Prepare repo for public visibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ venv/
 
 # Notebooks (may contain credentials)
 notebooks/
+*.ipynb
 
 # Copilot
 .copilot/

--- a/README.md
+++ b/README.md
@@ -2,6 +2,150 @@
 
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE) [![Python](https://img.shields.io/badge/python-3.11%2B-blue)](#) [![PyPI](https://img.shields.io/pypi/v/speechwire-mcp)](#)
 
-A [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) server that provides AI assistants with secure, authenticated access to  [SpeechWire](https://www.speechwire.com/) tournament data for speech-and-debate (forensics) competitions.
+A [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) server that provides AI assistants with secure, authenticated access to [SpeechWire](https://www.speechwire.com/) tournament data for speech-and-debate (forensics) competitions.
 
 The server scrapes manage.speechwire.com behind an authenticated session and exposes structured tournament data through MCP tools, enabling AI assistants to help tournament directors manage judge assignments, rooms, teams, entries, and round pairings.
+
+## Features
+
+- **Judge management** — list judges, contact info, availability, school associations, judge types, and add new judges
+- **Team & entry data** — team rosters, entries by team, hybrid/cross-school entries
+- **Room management** — room lists, usage grids, room-vs-section counts
+- **Schematics** — event lists, round-by-round pairings with judges, rooms, and competitors
+- **Tournament structure** — timeslots, competition groupings
+- **Results** — tab sheets with round outcomes, speaker scores, and placements
+- **Account discovery** — list and select accounts and tournaments interactively
+- **Session management** — automatic re-authentication on session expiry
+
+## Installation
+
+```bash
+pip install speechwire-mcp
+```
+
+Or install from source for development:
+
+```bash
+git clone https://github.com/jessica-writes-code/speechwire-mcp.git
+cd speechwire-mcp
+pip install -e ".[dev]"
+```
+
+## Configuration
+
+Set your SpeechWire credentials as environment variables:
+
+```bash
+export SPEECHWIRE_EMAIL="your-email@example.com"
+export SPEECHWIRE_PASSWORD="your-password"
+```
+
+Or copy the example file:
+
+```bash
+cp .env.example .env
+# Edit .env with your credentials
+```
+
+### Optional environment variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `SPEECHWIRE_ACCOUNT_ID` | *(discovered)* | Numeric account ID — skips account selection |
+| `SPEECHWIRE_CIRCUIT_ID` | *(discovered)* | Numeric circuit ID — skips tournament selection |
+| `SPEECHWIRE_TOURNAMENT_ID` | *(discovered)* | Numeric tournament ID — skips tournament selection |
+| `SPEECHWIRE_MCP_TRANSPORT` | `stdio` | Transport protocol: `stdio` or `sse` |
+| `SPEECHWIRE_MCP_HOST` | `127.0.0.1` | SSE bind host |
+| `SPEECHWIRE_MCP_PORT` | `8080` | SSE bind port |
+
+When account/circuit/tournament IDs are omitted, the server enters **discovery mode** — use the `speechwire_list_user_accounts` and `speechwire_list_user_tournaments` tools to browse and select interactively.
+
+## Usage
+
+### With an MCP client (e.g., Claude Desktop)
+
+Add to your MCP client configuration:
+
+```json
+{
+  "mcpServers": {
+    "speechwire": {
+      "command": "speechwire-mcp",
+      "env": {
+        "SPEECHWIRE_EMAIL": "your-email@example.com",
+        "SPEECHWIRE_PASSWORD": "your-password"
+      }
+    }
+  }
+}
+```
+
+### Running directly
+
+```bash
+# stdio transport (default)
+speechwire-mcp
+
+# SSE transport
+SPEECHWIRE_MCP_TRANSPORT=sse speechwire-mcp
+```
+
+## Available MCP Tools
+
+| Tool | Description |
+|------|-------------|
+| `speechwire_list_user_accounts` | List accounts available after login |
+| `speechwire_select_user_account` | Select an account to work with |
+| `speechwire_list_user_tournaments` | List tournaments for the selected account |
+| `speechwire_select_user_tournament` | Select a tournament to activate |
+| `speechwire_list_judges` | List all judges with roster details |
+| `speechwire_get_judge_contact` | Get judge email and phone |
+| `speechwire_get_judge_availability` | Get judge availability by timeslot |
+| `speechwire_get_judge_school` | Get judge's school association |
+| `speechwire_add_judge` | Add a new judge to the tournament |
+| `speechwire_list_judge_types` | List configured judge types |
+| `speechwire_list_rooms` | List tournament rooms |
+| `speechwire_get_room_usage` | Get room time-slot usage grid |
+| `speechwire_get_room_counts` | Get rooms vs. sections per grouping/round |
+| `speechwire_list_teams` | List registered teams |
+| `speechwire_get_team_entries` | Get entries for a specific team |
+| `speechwire_list_hybrid_entries` | List cross-school hybrid entries |
+| `speechwire_list_timeslots` | List tournament schedule timeslots |
+| `speechwire_list_groupings` | List competition groupings |
+| `speechwire_list_schematic_events` | List schematic events with available rounds |
+| `speechwire_get_round_schematic` | Get pairings for a specific event round |
+| `speechwire_get_tab_sheet` | Get results tab sheet for a grouping |
+
+## Development
+
+```bash
+pip install -e ".[dev]"
+ruff check src/ tests/
+pytest
+```
+
+CI runs on Python 3.11, 3.12, and 3.13.
+
+## Architecture
+
+```
+src/speechwire_mcp/
+├── server.py            # FastMCP server, tool definitions
+├── client.py            # SpeechWireClient (4-step auth), HTTP helpers
+├── parsing_helpers.py   # Shared BeautifulSoup utilities
+├── judges/              # Judge data retrieval and parsing
+├── login/               # Account & tournament discovery
+├── rooms/               # Room list, usage grid, counts
+├── schematics/          # Event list & round schematics
+├── structure/           # Timeslots & competition groupings
+├── teams/               # Team list, entries, hybrid entries
+└── results/             # Tab sheet results
+```
+
+Each domain module follows the same pattern:
+- `parsers.py` — pure functions that convert HTML → structured data
+- `client.py` — retrieval functions using the shared `_fetch_and_parse` helper
+
+## License
+
+[MIT](LICENSE)

--- a/README.md
+++ b/README.md
@@ -60,11 +60,7 @@ cp .env.example .env
 
 When account/circuit/tournament IDs are omitted, the server enters **discovery mode** — use the `speechwire_list_user_accounts` and `speechwire_list_user_tournaments` tools to browse and select interactively.
 
-## Usage
-
-### With an MCP client (e.g., Claude Desktop)
-
-Add to your MCP client configuration:
+### MCP client configuration
 
 ```json
 {
@@ -78,16 +74,6 @@ Add to your MCP client configuration:
     }
   }
 }
-```
-
-### Running directly
-
-```bash
-# stdio transport (default)
-speechwire-mcp
-
-# SSE transport
-SPEECHWIRE_MCP_TRANSPORT=sse speechwire-mcp
 ```
 
 ## Available MCP Tools
@@ -115,36 +101,6 @@ SPEECHWIRE_MCP_TRANSPORT=sse speechwire-mcp
 | `speechwire_list_schematic_events` | List schematic events with available rounds |
 | `speechwire_get_round_schematic` | Get pairings for a specific event round |
 | `speechwire_get_tab_sheet` | Get results tab sheet for a grouping |
-
-## Development
-
-```bash
-pip install -e ".[dev]"
-ruff check src/ tests/
-pytest
-```
-
-CI runs on Python 3.11, 3.12, and 3.13.
-
-## Architecture
-
-```
-src/speechwire_mcp/
-├── server.py            # FastMCP server, tool definitions
-├── client.py            # SpeechWireClient (4-step auth), HTTP helpers
-├── parsing_helpers.py   # Shared BeautifulSoup utilities
-├── judges/              # Judge data retrieval and parsing
-├── login/               # Account & tournament discovery
-├── rooms/               # Room list, usage grid, counts
-├── schematics/          # Event list & round schematics
-├── structure/           # Timeslots & competition groupings
-├── teams/               # Team list, entries, hybrid entries
-└── results/             # Tab sheet results
-```
-
-Each domain module follows the same pattern:
-- `parsers.py` — pure functions that convert HTML → structured data
-- `client.py` — retrieval functions using the shared `_fetch_and_parse` helper
 
 ## License
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,9 +40,9 @@ dev = [
 speechwire-mcp = "speechwire_mcp.server:main"
 
 [project.urls]
-Homepage = "https://github.com/jessicamoore/SpeechWireMCP"
-Repository = "https://github.com/jessicamoore/SpeechWireMCP"
-Issues = "https://github.com/jessicamoore/SpeechWireMCP/issues"
+Homepage = "https://github.com/jessica-writes-code/speechwire-mcp"
+Repository = "https://github.com/jessica-writes-code/speechwire-mcp"
+Issues = "https://github.com/jessica-writes-code/speechwire-mcp/issues"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/speechwire_mcp"]

--- a/tests/test_login_parsers.py
+++ b/tests/test_login_parsers.py
@@ -193,8 +193,8 @@ MALFORMED_TOURNAMENTS_HTML = """<html><body>
 </body></html>
 """
 
-# Realistic SpeechWire HTML: <select name="tournid"> inside forms
-REAL_SPEECHWIRE_HTML = """<!DOCTYPE html>
+# Sample SpeechWire HTML: <select name="tournid"> inside forms
+SAMPLE_TOURNAMENT_SELECT_HTML = """<!DOCTYPE html>
 <html>
 <head><title>Tournaments</title></head>
 <body>
@@ -220,7 +220,7 @@ REAL_SPEECHWIRE_HTML = """<!DOCTYPE html>
 </html>
 """
 
-REAL_SPEECHWIRE_NO_DATE_HTML = """<html><body>
+SAMPLE_NO_DATE_HTML = """<html><body>
   <form name="formaddexisting">
     <select name='tournid'>
       <option value='99999'>Practice Round No Date</option>
@@ -230,7 +230,7 @@ REAL_SPEECHWIRE_NO_DATE_HTML = """<html><body>
 </body></html>
 """
 
-REAL_SPEECHWIRE_EMPTY_SELECT_HTML = """<html><body>
+SAMPLE_EMPTY_SELECT_HTML = """<html><body>
   <form name="formaddexisting">
     <select name='tournid'>
       <option value=''>-- Select --</option>
@@ -240,7 +240,7 @@ REAL_SPEECHWIRE_EMPTY_SELECT_HTML = """<html><body>
 </body></html>
 """
 
-REAL_SPEECHWIRE_NO_CIRCUIT_HTML = """<html><body>
+SAMPLE_NO_CIRCUIT_HTML = """<html><body>
   <form name="formaddexisting">
     <select name='tournid'>
       <option value='30001'>Solo Tourney (Jan. 1, 2026)</option>
@@ -249,7 +249,7 @@ REAL_SPEECHWIRE_NO_CIRCUIT_HTML = """<html><body>
 </body></html>
 """
 
-REAL_SPEECHWIRE_DATE_RANGE_HTML = """<html><body>
+SAMPLE_DATE_RANGE_HTML = """<html><body>
   <form name="formaddexisting">
     <select name='tournid'>
       <option value='40001'>Weekend Invitational (Feb. 14-15, 2026)</option>
@@ -381,56 +381,56 @@ class TestParseTournamentListHtml:
 class TestParseTournamentListSelectStrategy:
     """Tests for Strategy 1: <select name="tournid"> (real SpeechWire HTML)."""
 
-    def test_real_html_extracts_all_seasons(self):
-        result = parse_tournament_list_html(REAL_SPEECHWIRE_HTML)
+    def test_sample_html_extracts_all_seasons(self):
+        result = parse_tournament_list_html(SAMPLE_TOURNAMENT_SELECT_HTML)
         # 3 current + 2 past tournaments
         assert len(result) == 5
         tourn_ids = {r["tournament_id"] for r in result}
         assert tourn_ids == {20022, 20074, 21289, 10001, 10002}
 
-    def test_real_html_extracts_circuit_id(self):
-        result = parse_tournament_list_html(REAL_SPEECHWIRE_HTML)
+    def test_sample_html_extracts_circuit_id(self):
+        result = parse_tournament_list_html(SAMPLE_TOURNAMENT_SELECT_HTML)
         for rec in result:
             assert rec["circuit_id"] == 25
 
-    def test_real_html_extracts_names(self):
-        result = parse_tournament_list_html(REAL_SPEECHWIRE_HTML)
+    def test_sample_html_extracts_names(self):
+        result = parse_tournament_list_html(SAMPLE_TOURNAMENT_SELECT_HTML)
         names = [r["name"] for r in result]
         assert any("Bartlet" in n for n in names)
         assert any("Thanksgiving" in n for n in names)
         assert any("National Qualifiers" in n for n in names)
 
-    def test_real_html_extracts_dates(self):
-        result = parse_tournament_list_html(REAL_SPEECHWIRE_HTML)
+    def test_sample_html_extracts_dates(self):
+        result = parse_tournament_list_html(SAMPLE_TOURNAMENT_SELECT_HTML)
         dates = {r["tournament_id"]: r["date"] for r in result}
         assert dates[20022] == "Oct. 25, 2025"
         assert dates[20074] == "Nov. 22, 2025"
         assert dates[21289] == "Mar. 7, 2026"
 
     def test_no_date_returns_none(self):
-        result = parse_tournament_list_html(REAL_SPEECHWIRE_NO_DATE_HTML)
+        result = parse_tournament_list_html(SAMPLE_NO_DATE_HTML)
         assert len(result) == 1
         assert result[0]["date"] is None
         assert result[0]["name"] == "Practice Round No Date"
 
     def test_empty_option_values_skipped(self):
-        result = parse_tournament_list_html(REAL_SPEECHWIRE_EMPTY_SELECT_HTML)
+        result = parse_tournament_list_html(SAMPLE_EMPTY_SELECT_HTML)
         assert result == []
 
     def test_missing_circuit_id_returns_none(self):
-        result = parse_tournament_list_html(REAL_SPEECHWIRE_NO_CIRCUIT_HTML)
+        result = parse_tournament_list_html(SAMPLE_NO_CIRCUIT_HTML)
         assert len(result) == 1
         assert result[0]["circuit_id"] is None
         assert result[0]["tournament_id"] == 30001
         assert result[0]["date"] == "Jan. 1, 2026"
 
     def test_date_range_parsing(self):
-        result = parse_tournament_list_html(REAL_SPEECHWIRE_DATE_RANGE_HTML)
+        result = parse_tournament_list_html(SAMPLE_DATE_RANGE_HTML)
         assert len(result) == 1
         assert result[0]["date"] == "Feb. 14-15, 2026"
 
     def test_records_have_required_keys(self):
-        result = parse_tournament_list_html(REAL_SPEECHWIRE_HTML)
+        result = parse_tournament_list_html(SAMPLE_TOURNAMENT_SELECT_HTML)
         for rec in result:
             assert "tournament_id" in rec
             assert "circuit_id" in rec


### PR DESCRIPTION
## Summary

Pre-public cleanup addressing issues found during the security/quality audit.

### Changes

1. **Fix `pyproject.toml` URLs** — corrected from `jessicamoore/SpeechWireMCP` to `jessica-writes-code/speechwire-mcp` (Homepage, Repository, Issues)

2. **Write comprehensive README** — expanded from 7 lines to full documentation:
   - Installation (PyPI + source)
   - Configuration (env vars, discovery mode)
   - Usage (MCP client config, direct invocation)
   - All 21 MCP tools documented in a table
   - Development workflow
   - Architecture overview

3. **Add `*.ipynb` to `.gitignore`** — prevents accidental notebook commits containing credentials

4. **Rename `REAL_SPEECHWIRE_*` test fixtures** — renamed to `SAMPLE_*` convention to avoid implying production data was scraped

### Testing
All 210 tests pass. Ruff clean.