### PR TITLE
feat: add judge email and availability update tools

### DIFF
--- a/src/speechwire_mcp/judges/__init__.py
+++ b/src/speechwire_mcp/judges/__init__.py
@@ -5,6 +5,8 @@ from speechwire_mcp.judges.client import (
     get_judge_school,
     add_judge,
     get_judge_types,
+    update_judge_email,
+    update_judge_availability,
 )
 
 __all__ = [
@@ -14,4 +16,6 @@ __all__ = [
     "get_judge_school",
     "add_judge",
     "get_judge_types",
+    "update_judge_email",
+    "update_judge_availability",
 ]

--- a/src/speechwire_mcp/judges/client.py
+++ b/src/speechwire_mcp/judges/client.py
@@ -1,4 +1,5 @@
 import logging
+import re
 
 from speechwire_mcp.client import SpeechWireClient, _fetch_and_parse, _post_and_parse
 from speechwire_mcp.judges.parsers import (
@@ -7,10 +8,14 @@ from speechwire_mcp.judges.parsers import (
     parse_availability_from_edit_html,
     parse_school_from_edit_html,
     parse_add_judge_response,
+    parse_edit_form_values,
+    parse_edit_judge_response,
     parse_judge_types_from_html,
 )
 
 logger = logging.getLogger(__name__)
+
+_EMAIL_RE = re.compile(r"^[\w\.\+\-]+@[\w\.\-]+\.\w+$")
 
 
 def get_judge_list(client: SpeechWireClient) -> list[dict]:
@@ -207,4 +212,163 @@ def get_judge_types(client: SpeechWireClient) -> list[dict]:
         parse_judge_types_from_html,
         default=[],
         context="judge types list",
+    )
+
+
+_EDIT_JUDGE_URL = "https://manage.speechwire.com/tabroom/judges-edit.php"
+
+
+def _prefetch_edit_form(judge_id: int, client: SpeechWireClient) -> dict | None:
+    """Prefetch the judge edit form and return current field values.
+
+    Parameters
+    ----------
+    judge_id : int
+        The judge to fetch.
+    client : SpeechWireClient
+        Authenticated client.
+
+    Returns
+    -------
+    dict | None
+        Parsed form values, or ``None`` on failure.
+    """
+    result = _fetch_and_parse(
+        client,
+        _EDIT_JUDGE_URL,
+        parse_edit_form_values,
+        default=None,
+        context=f"edit form prefetch for judge {judge_id}",
+        params={"judgeid": str(judge_id)},
+    )
+    return result
+
+
+def _build_edit_form_data(
+    judge_id: int,
+    current: dict,
+    available_slots: list[int],
+) -> dict[str, str]:
+    """Build the complete form payload for a judge edit POST.
+
+    Parameters
+    ----------
+    judge_id : int
+        The judge being edited.
+    current : dict
+        Current form values from ``parse_edit_form_values``.  Must include
+        ``fields`` (all serialised form controls) and optionally
+        ``hidden_fields`` (legacy key, merged for backward compatibility).
+    available_slots : list[int]
+        Slot indices to mark as available (checked).
+
+    Returns
+    -------
+    dict[str, str]
+        Form data ready for POST.
+    """
+    # Start with all serialised form fields (text, select, hidden inputs).
+    form_data: dict[str, str] = dict(current.get("fields") or {})
+
+    # Merge legacy hidden_fields key if present (earlier security fix).
+    form_data.update(current.get("hidden_fields") or {})
+
+    # Slot checkboxes
+    for slot in available_slots:
+        form_data[f"slotunblock[{slot}]"] = "1"
+
+    # Explicit overrides — these must win regardless of serialised values.
+    form_data["mode"] = "editjudge"
+    form_data["judgeid"] = str(judge_id)
+    form_data["Submit"] = "Save changes"
+
+    return form_data
+
+
+def update_judge_email(judge_id: int, email: str, client: SpeechWireClient) -> dict:
+    """Update a judge's email address via the edit form.
+
+    Uses a prefetch→merge→POST pattern because the SpeechWire edit form
+    submits all fields together.
+
+    Parameters
+    ----------
+    judge_id : int
+        ID of the judge to update.
+    email : str
+        New email address.
+    client : SpeechWireClient
+        Authenticated client with a tournament selected.
+
+    Returns
+    -------
+    dict
+        ``{"success": bool, "judge_id": int | None, "error": str | None}``
+    """
+    _default: dict = {"success": False, "judge_id": None, "error": "unexpected error"}
+
+    if not email or not email.strip():
+        return {"success": False, "judge_id": None, "error": "email is required"}
+
+    email = email.strip()
+    if not _EMAIL_RE.match(email):
+        return {"success": False, "judge_id": None, "error": "invalid email format"}
+
+    current = _prefetch_edit_form(judge_id, client)
+    if current is None:
+        return {"success": False, "judge_id": None, "error": "failed to prefetch edit form"}
+
+    form_data = _build_edit_form_data(judge_id, current, current["available_slots"])
+    form_data["judgeemail"] = email.strip()
+
+    return _post_and_parse(
+        client,
+        _EDIT_JUDGE_URL,
+        form_data,
+        parse_edit_judge_response,
+        default=_default,
+        context=f"update email for judge {judge_id}",
+    )
+
+
+def update_judge_availability(
+    judge_id: int,
+    available_slots: list[int],
+    client: SpeechWireClient,
+) -> dict:
+    """Update a judge's availability slots via the edit form.
+
+    Uses a prefetch→merge→POST pattern because the SpeechWire edit form
+    submits all fields together.
+
+    Parameters
+    ----------
+    judge_id : int
+        ID of the judge to update.
+    available_slots : list[int]
+        Slot indices the judge should be available for. Replaces any
+        previously checked slots.
+    client : SpeechWireClient
+        Authenticated client with a tournament selected.
+
+    Returns
+    -------
+    dict
+        ``{"success": bool, "judge_id": int | None, "error": str | None}``
+    """
+    _default: dict = {"success": False, "judge_id": None, "error": "unexpected error"}
+
+    current = _prefetch_edit_form(judge_id, client)
+    if current is None:
+        return {"success": False, "judge_id": None, "error": "failed to prefetch edit form"}
+
+    form_data = _build_edit_form_data(judge_id, current, available_slots)
+
+    return _post_and_parse(
+        client,
+        _EDIT_JUDGE_URL,
+        form_data,
+        parse_edit_judge_response,
+        default=_default,
+        context=f"update availability for judge {judge_id}",
     )

--- a/src/speechwire_mcp/judges/parsers.py
+++ b/src/speechwire_mcp/judges/parsers.py
@@ -330,6 +330,151 @@ def parse_add_judge_response(html: str) -> dict:
     return {"success": False, "judge_id": None, "error": "ambiguous response (no success signal)"}
 
 
+def parse_edit_form_values(html: str) -> dict | None:
+    """Extract all current form field values from a judge edit page.
+
+    Parses input values, selected options, and checked checkboxes so that the
+    caller can re-submit the form with selective modifications (prefetch→merge→POST).
+
+    All extraction is scoped to the edit-judge form (``form#form1`` containing
+    ``mode=editjudge``).  If the form is not found the page is not a valid
+    edit page and ``None`` is returned so that callers abort before POSTing
+    destructive blank data.
+
+    Parameters
+    ----------
+    html : str
+        Raw HTML of the ``judges-edit.php`` page for an existing judge.
+
+    Returns
+    -------
+    dict | None
+        ``None`` when the edit form is not found.  Otherwise a dict with:
+        ``fields`` (``dict[str, str]`` — all text/select/hidden inputs),
+        ``available_slots`` (``list[int]`` — checked slot indices).
+    """
+    soup = make_soup(html)
+
+    # Scope to the edit-judge form only; the page may also contain formtime.
+    form = soup.find("form", {"id": "form1"})
+    if form is None:
+        return None
+    # Verify this is the edit-judge form
+    mode_input = form.find("input", {"name": "mode", "value": "editjudge"})
+    if mode_input is None:
+        return None
+
+    _SKIP_FIELDS = {"mode", "judgeid"}
+
+    fields: dict[str, str] = {}
+
+    # Text and hidden inputs
+    for inp in form.find_all("input", {"type": ["text", "hidden"]}):
+        name = (inp.get("name") or "").strip()
+        if name and name not in _SKIP_FIELDS:
+            fields[name] = (inp.get("value", "") or "").strip()
+
+    # Selects — fall back to first option when none is explicitly selected
+    for select in form.find_all("select"):
+        name = (select.get("name") or "").strip()
+        if not name or name in _SKIP_FIELDS:
+            continue
+        option = select.find("option", selected=True) or select.find("option")
+        fields[name] = (option.get("value", "") if option else "").strip()
+
+    # Checked slot checkboxes → list of slot indices
+    available_slots: list[int] = []
+    for inp in form.find_all("input", {"type": "checkbox"}):
+        cb_name = inp.get("name", "") or ""
+        m = re.match(r"slotunblock\[(\d+)\]", cb_name)
+        if m and inp.has_attr("checked"):
+            available_slots.append(int(m.group(1)))
+    available_slots.sort()
+
+    return {
+        "fields": fields,
+        "available_slots": available_slots,
+    }
+
+
+def parse_edit_judge_response(html: str) -> dict:
+    """Detect success or error after a judge-edit POST.
+
+    The edit form re-renders on both success and failure (unlike add-judge
+    which redirects on success), so detection relies on the presence or
+    absence of error text.
+
+    Parameters
+    ----------
+    html : str
+        Raw HTML response from ``judges-edit.php`` after a POST.
+
+    Returns
+    -------
+    dict
+        ``{"success": bool, "judge_id": int | None, "error": str | None}``
+    """
+    soup = make_soup(html)
+
+    # --- error signals ---
+    error_texts: list[str] = []
+    for tag in soup.find_all(["p", "div"]):
+        text = tag.get_text(" ", strip=True)
+        if text and "error" in text.lower():
+            error_texts.append(text)
+
+    no_judge = bool(soup.find(string=lambda s: s and "No judge specified" in s))
+    has_error = bool(error_texts) or no_judge
+
+    # --- extract judge_id ---
+    judge_id: int | None = None
+    judge_id_input = soup.find("input", {"name": "judgeid"})
+    if judge_id_input:
+        try:
+            judge_id = int(judge_id_input.get("value", ""))
+        except (ValueError, TypeError):
+            pass
+
+    if judge_id is None:
+        for a in soup.find_all("a", href=True):
+            href = a["href"]
+            if "judgeid=" in href:
+                judge_id = extract_int_query_param(a, "judgeid")
+                if judge_id is not None:
+                    break
+
+    # --- success signals ---
+    success_msg = soup.find("div", class_="successmsg")
+    body_text = soup.get_text(" ", strip=True).lower()
+    has_success = (
+        success_msg is not None
+        or "judge saved" in body_text
+        or "successfully" in body_text
+    )
+
+    if has_error:
+        # Sanitise: never forward raw HTML error text (may contain PII).
+        if error_texts:
+            raw = error_texts[0].lower()
+            safe_error = (
+                "judge not found"
+                if "no judge" in raw
+                else "edit failed (server rejected the change)"
+            )
+        else:
+            safe_error = "edit failed"
+        return {
+            "success": False,
+            "judge_id": None,
+            "error": safe_error,
+        }
+
+    if has_success:
+        return {"success": True, "judge_id": judge_id, "error": None}
+
+    return {"success": False, "judge_id": None, "error": "ambiguous response (no success signal)"}
+
+
 def parse_judge_types_from_html(html: str) -> list[dict]:
     """Parse the judge types list page into structured records.
 

--- a/src/speechwire_mcp/server.py
+++ b/src/speechwire_mcp/server.py
@@ -33,6 +33,8 @@ from speechwire_mcp.judges import (
     get_judge_school,
     add_judge,
     get_judge_types,
+    update_judge_email,
+    update_judge_availability,
 )
 from speechwire_mcp.schematics import (
     get_schematic_events,
@@ -394,6 +396,63 @@ def speechwire_add_judge(
             available_slots=available_slots,
         ),
         "Failed to add judge",
+        default={"success": False, "judge_id": None, "error": "unexpected error"},
+        require_tournament=True,
+    )
+
+
+@mcp.tool()
+def speechwire_update_judge_email(judge_id: int, email: str) -> dict:
+    """Update a judge's email address.
+
+    Prefetches the current edit form, merges the new email, and re-submits
+    all fields so that no existing values are lost.
+
+    Parameters
+    ----------
+    judge_id : int
+        ID of the judge to update.
+    email : str
+        New email address for the judge.
+
+    Returns
+    -------
+    dict
+        ``{"success": bool, "judge_id": int | None, "error": str | None}``
+    """
+    return _safe_tool_call(
+        lambda: update_judge_email(judge_id, email, _get_client()),
+        f"Failed to update email for judge {judge_id}",
+        default={"success": False, "judge_id": None, "error": "unexpected error"},
+        require_tournament=True,
+    )
+
+
+@mcp.tool()
+def speechwire_update_judge_availability(
+    judge_id: int, available_slots: list[int]
+) -> dict:
+    """Update a judge's availability slots.
+
+    Prefetches the current edit form, replaces the slot checkboxes with the
+    provided list, and re-submits all fields so that no existing values are lost.
+
+    Parameters
+    ----------
+    judge_id : int
+        ID of the judge to update.
+    available_slots : list[int]
+        Slot indices the judge should be available for.
+        Get valid slot numbers from speechwire_list_timeslots.
+
+    Returns
+    -------
+    dict
+        ``{"success": bool, "judge_id": int | None, "error": str | None}``
+    """
+    return _safe_tool_call(
+        lambda: update_judge_availability(judge_id, available_slots, _get_client()),
+        f"Failed to update availability for judge {judge_id}",
         default={"success": False, "judge_id": None, "error": "unexpected error"},
         require_tournament=True,
     )

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -654,3 +654,263 @@ class TestParseJudgeTypes:
             assert "judge_type_id" in record
             assert "judge_type" in record
             assert "groupings" in record
+
+
+# ---------------------------------------------------------------------------
+# Edit form values parser tests
+# ---------------------------------------------------------------------------
+
+SAMPLE_EDIT_FORM_HTML = f"""<!DOCTYPE html>
+<html><head><title>SpeechWire</title></head>
+<body>
+<p class='pagetitle'>Edit judge</p>
+<form id="form1" name="form1" method="post" action="judges-edit.php">
+<p class='sectiontitle'>General information</p>
+<p>Name: <input class='swtext' id='judgename' type='text' name='judgename' \
+value="{DONNA_MOSS}" size='30' maxlength='50'>
+Email address: <input class='swtext' id='judgeemail' type='text' name='judgeemail' \
+value="{email_for(DONNA_MOSS)}" size='30' maxlength='50'></p>
+<p>Team: <select id='teamid' name='teamid'><option value='20'>Some School</option>\
+<option selected value='21'>{MANCHESTER_PREP}</option></select></p>
+<p>Clean/Neutral judge? <select id='judgeisclean' name='judgeisclean'>\
+<option selected value='0'>No</option><option value='1'>Yes</option></select>
+Active? <select id='judgeactive' name='judgeactive'>\
+<option value='0'>No</option><option selected value='1'>Yes</option></select>
+Priority? <select id='judgeispriority' name='judgeispriority'>\
+<option selected value='0'>No</option><option value='1'>Yes</option></select></p>
+<p><input name="Submit" type="submit" value="Save changes">
+<input name='mode' id="mode" type="hidden" value="editjudge" />
+<input name='judgeid' id="judgeid" type="hidden" value="42" /></p>
+<p class='sectiontitle'>Availability by timeslot</p>
+<table class='dd'>\
+<tr class='tableheader'><td>Sat. 9:00 AM</td><td>Sat. 10:45 AM</td>\
+<td>Sat. 1:00 PM</td><td>Sat. 3:30 PM</td></tr>
+<tr><td><input type="checkbox" name="slotunblock[3]" value="1" checked></td>
+<td><input type="checkbox" name="slotunblock[4]" value="1" checked></td>
+<td><input type="checkbox" name="slotunblock[5]" value="1"></td>
+<td><input type="checkbox" name="slotunblock[6]" value="1"></td></tr></table>
+</form></body></html>"""
+
+
+def _import_parse_edit_form_values():
+    try:
+        from speechwire_mcp.judges.parsers import parse_edit_form_values
+
+        return parse_edit_form_values
+    except ImportError:
+        pytest.skip("parse_edit_form_values not implemented yet")
+
+
+class TestParseEditFormValues:
+    def test_extracts_judgename(self):
+        parse = _import_parse_edit_form_values()
+        result = parse(SAMPLE_EDIT_FORM_HTML)
+        assert result["fields"]["judgename"] == DONNA_MOSS
+
+    def test_extracts_judgeemail(self):
+        parse = _import_parse_edit_form_values()
+        result = parse(SAMPLE_EDIT_FORM_HTML)
+        assert result["fields"]["judgeemail"] == email_for(DONNA_MOSS)
+
+    def test_extracts_teamid(self):
+        parse = _import_parse_edit_form_values()
+        result = parse(SAMPLE_EDIT_FORM_HTML)
+        assert result["fields"]["teamid"] == "21"
+
+    def test_select_judgeisclean(self):
+        parse = _import_parse_edit_form_values()
+        result = parse(SAMPLE_EDIT_FORM_HTML)
+        assert result["fields"]["judgeisclean"] == "0"
+
+    def test_select_judgeactive(self):
+        parse = _import_parse_edit_form_values()
+        result = parse(SAMPLE_EDIT_FORM_HTML)
+        assert result["fields"]["judgeactive"] == "1"
+
+    def test_select_judgeispriority(self):
+        parse = _import_parse_edit_form_values()
+        result = parse(SAMPLE_EDIT_FORM_HTML)
+        assert result["fields"]["judgeispriority"] == "0"
+
+    def test_available_slots_only_checked(self):
+        parse = _import_parse_edit_form_values()
+        result = parse(SAMPLE_EDIT_FORM_HTML)
+        assert result["available_slots"] == [3, 4]
+
+    def test_empty_html_returns_defaults(self):
+        parse = _import_parse_edit_form_values()
+        result = parse("")
+        assert result is None
+
+    def test_result_has_all_expected_keys(self):
+        parse = _import_parse_edit_form_values()
+        result = parse(SAMPLE_EDIT_FORM_HTML)
+        assert set(result.keys()) == {"fields", "available_slots"}
+
+    def test_returns_none_for_non_edit_page(self):
+        parse = _import_parse_edit_form_values()
+        html = "<html><body><p>No form here</p></body></html>"
+        assert parse(html) is None
+
+    def test_second_form_not_contaminated(self):
+        parse = _import_parse_edit_form_values()
+        html = f"""<!DOCTYPE html>
+<html><body>
+<form id="form1" method="post" action="judges-edit.php">
+<input name='mode' type='hidden' value='editjudge' />
+<input name='judgeid' type='hidden' value='42' />
+<input name='judgename' type='text' value='{DONNA_MOSS}' />
+<input type="checkbox" name="slotunblock[1]" value="1" checked>
+</form>
+<form id="form2">
+<input type="checkbox" name="slotunblock[99]" value="1" checked>
+</form>
+</body></html>"""
+        result = parse(html)
+        assert result["available_slots"] == [1]
+        assert 99 not in result["available_slots"]
+
+    def test_select_defaults_to_first_option(self):
+        parse = _import_parse_edit_form_values()
+        html = """<!DOCTYPE html>
+<html><body>
+<form id="form1" method="post" action="judges-edit.php">
+<input name='mode' type='hidden' value='editjudge' />
+<input name='judgeid' type='hidden' value='42' />
+<select name='teamid'>
+  <option value='10'>First</option>
+  <option value='20'>Second</option>
+</select>
+</form></body></html>"""
+        result = parse(html)
+        assert result["fields"]["teamid"] == "10"
+
+    def test_preserves_hidden_inputs(self):
+        parse = _import_parse_edit_form_values()
+        html = """<!DOCTYPE html>
+<html><body>
+<form id="form1" method="post" action="judges-edit.php">
+<input name='mode' type='hidden' value='editjudge' />
+<input name='judgeid' type='hidden' value='42' />
+<input name='csrf_token' type='hidden' value='abc123' />
+</form></body></html>"""
+        result = parse(html)
+        assert result["fields"]["csrf_token"] == "abc123"
+        assert "mode" not in result["fields"]
+        assert "judgeid" not in result["fields"]
+
+    def test_preserves_coach_field(self):
+        parse = _import_parse_edit_form_values()
+        html = f"""<!DOCTYPE html>
+<html><body>
+<form id="form1" method="post" action="judges-edit.php">
+<input name='mode' type='hidden' value='editjudge' />
+<input name='judgeid' type='hidden' value='42' />
+<input name='judgename' type='text' value='{DONNA_MOSS}' />
+<input name='judgeiscoach' type='text' value='1' />
+</form></body></html>"""
+        result = parse(html)
+        assert result["fields"]["judgeiscoach"] == "1"
+
+
+# ---------------------------------------------------------------------------
+# Edit judge response parser tests
+# ---------------------------------------------------------------------------
+
+EDIT_JUDGE_SUCCESS_HTML = """<!DOCTYPE html>
+<html><body>
+<form id="form1" method="post" action="judges-edit.php">
+<input name='mode' type='hidden' value='editjudge' />
+<input name='judgeid' type='hidden' value='42' />
+<input name='judgename' value='Test Judge' />
+</form></body></html>"""
+
+EDIT_JUDGE_ERROR_HTML = """<!DOCTYPE html>
+<html><body>
+<p>Error: email address is invalid</p>
+<form id="form1" method="post" action="judges-edit.php">
+<input name='mode' type='hidden' value='editjudge' />
+<input name='judgeid' type='hidden' value='42' />
+</form></body></html>"""
+
+EDIT_JUDGE_NO_JUDGE_HTML = """<!DOCTYPE html>
+<html><body>
+<p>No judge specified</p>
+</body></html>"""
+
+EDIT_JUDGE_AMBIGUOUS_HTML = """<!DOCTYPE html>
+<html><body>
+<p>Some unrelated content</p>
+</body></html>"""
+
+
+def _import_parse_edit_judge_response():
+    try:
+        from speechwire_mcp.judges.parsers import parse_edit_judge_response
+
+        return parse_edit_judge_response
+    except ImportError:
+        pytest.skip("parse_edit_judge_response not implemented yet")
+
+
+class TestParseEditJudgeResponse:
+    def test_mode_editjudge_alone_is_ambiguous(self):
+        parse = _import_parse_edit_judge_response()
+        result = parse(EDIT_JUDGE_SUCCESS_HTML)
+        assert result["success"] is False
+
+    def test_error_text_detected(self):
+        parse = _import_parse_edit_judge_response()
+        result = parse(EDIT_JUDGE_ERROR_HTML)
+        assert result["success"] is False
+        assert result["error"] == "edit failed (server rejected the change)"
+
+    def test_no_judge_specified(self):
+        parse = _import_parse_edit_judge_response()
+        result = parse(EDIT_JUDGE_NO_JUDGE_HTML)
+        assert result["success"] is False
+        assert result["error"] is not None
+
+    def test_ambiguous_response(self):
+        parse = _import_parse_edit_judge_response()
+        result = parse(EDIT_JUDGE_AMBIGUOUS_HTML)
+        assert result["success"] is False
+        assert result["judge_id"] is None
+        assert "ambiguous" in result["error"].lower()
+
+    def test_judge_id_extracted(self):
+        parse = _import_parse_edit_judge_response()
+        result = parse(EDIT_JUDGE_SUCCESS_HTML)
+        assert result["judge_id"] is None or isinstance(result["judge_id"], int)
+
+    def test_empty_html_returns_failure(self):
+        parse = _import_parse_edit_judge_response()
+        result = parse("")
+        assert result["success"] is False
+        assert result["judge_id"] is None
+
+    def test_success_with_success_msg(self):
+        parse = _import_parse_edit_judge_response()
+        html = """<!DOCTYPE html>
+<html><body>
+<div class="successmsg">Changes saved</div>
+<form id="form1" method="post" action="judges-edit.php">
+<input name='judgeid' type='hidden' value='42' />
+</form></body></html>"""
+        result = parse(html)
+        assert result["success"] is True
+        assert result["judge_id"] == 42
+        assert result["error"] is None
+
+    def test_success_with_judge_saved_text(self):
+        parse = _import_parse_edit_judge_response()
+        html = """<!DOCTYPE html>
+<html><body>
+<p>judge saved</p>
+<form id="form1" method="post" action="judges-edit.php">
+<input name='judgeid' type='hidden' value='42' />
+</form></body></html>"""
+        result = parse(html)
+        assert result["success"] is True
+        assert result["judge_id"] == 42
+        assert result["error"] is None

--- a/tests/test_update_judge.py
+++ b/tests/test_update_judge.py
@@ -1,0 +1,320 @@
+"""Tests for update_judge_email and update_judge_availability."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from fake_data import DONNA_MOSS, email_for
+
+
+def _import_update_judge_email():
+    try:
+        from speechwire_mcp.judges.client import update_judge_email
+
+        return update_judge_email
+    except ImportError:
+        pytest.skip("update_judge_email not implemented yet")
+
+
+def _import_update_judge_availability():
+    try:
+        from speechwire_mcp.judges.client import update_judge_availability
+
+        return update_judge_availability
+    except ImportError:
+        pytest.skip("update_judge_availability not implemented yet")
+
+
+MOCK_CURRENT_VALUES = {
+    "fields": {
+        "judgename": DONNA_MOSS,
+        "judgeemail": email_for(DONNA_MOSS),
+        "teamid": "21",
+        "judgeisclean": "0",
+        "judgeactive": "1",
+        "judgeispriority": "0",
+    },
+    "available_slots": [3, 4],
+}
+
+
+# ---------------------------------------------------------------------------
+# Email validation tests
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateJudgeEmailValidation:
+    def test_rejects_empty_email(self):
+        update = _import_update_judge_email()
+        client = MagicMock()
+        result = update(42, "", client)
+        assert result["success"] is False
+        assert result["error"] is not None
+        assert "email" in result["error"].lower()
+
+    def test_rejects_whitespace_only_email(self):
+        update = _import_update_judge_email()
+        client = MagicMock()
+        result = update(42, "   ", client)
+        assert result["success"] is False
+        assert result["error"] is not None
+
+    def test_rejects_invalid_email_format(self):
+        update = _import_update_judge_email()
+        client = MagicMock()
+        result = update(42, "not-an-email", client)
+        assert result["success"] is False
+        assert "email" in result["error"].lower()
+
+    def test_rejects_email_with_newlines(self):
+        update = _import_update_judge_email()
+        client = MagicMock()
+        result = update(42, "test@example.com\r\nBcc: evil@attacker.com", client)
+        assert result["success"] is False
+        assert "email" in result["error"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Email form data tests
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateJudgeEmailFormData:
+    def test_prefetch_happens(self):
+        update = _import_update_judge_email()
+
+        with (
+            patch(
+                "speechwire_mcp.judges.client._fetch_and_parse",
+                return_value=MOCK_CURRENT_VALUES.copy(),
+            ) as mock_fetch,
+            patch(
+                "speechwire_mcp.judges.client._post_and_parse",
+                return_value={"success": True, "judge_id": 42, "error": None},
+            ),
+        ):
+            update(42, "new@example.com", MagicMock())
+
+        mock_fetch.assert_called_once()
+        call_args = mock_fetch.call_args
+        url = call_args[0][1] if len(call_args[0]) > 1 else call_args[1].get("url")
+        assert "judges-edit.php" in url
+        params = call_args[1].get("params", {}) if call_args[1] else {}
+        assert params.get("judgeid") == "42"
+
+    def test_post_form_data_has_required_fields(self):
+        update = _import_update_judge_email()
+
+        with (
+            patch(
+                "speechwire_mcp.judges.client._fetch_and_parse",
+                return_value=MOCK_CURRENT_VALUES.copy(),
+            ),
+            patch(
+                "speechwire_mcp.judges.client._post_and_parse",
+                return_value={"success": True, "judge_id": 42, "error": None},
+            ) as mock_post,
+        ):
+            update(42, "new@example.com", MagicMock())
+
+        call_args = mock_post.call_args
+        data = call_args[0][2] if len(call_args[0]) > 2 else call_args[1].get("data")
+        assert data["mode"] == "editjudge"
+        assert data["judgeid"] == "42"
+        assert data["Submit"] == "Save changes"
+
+    def test_email_is_replaced(self):
+        update = _import_update_judge_email()
+
+        with (
+            patch(
+                "speechwire_mcp.judges.client._fetch_and_parse",
+                return_value=MOCK_CURRENT_VALUES.copy(),
+            ),
+            patch(
+                "speechwire_mcp.judges.client._post_and_parse",
+                return_value={"success": True, "judge_id": 42, "error": None},
+            ) as mock_post,
+        ):
+            update(42, "new@example.com", MagicMock())
+
+        call_args = mock_post.call_args
+        data = call_args[0][2] if len(call_args[0]) > 2 else call_args[1].get("data")
+        assert data["judgeemail"] == "new@example.com"
+
+    def test_other_fields_preserved(self):
+        update = _import_update_judge_email()
+
+        with (
+            patch(
+                "speechwire_mcp.judges.client._fetch_and_parse",
+                return_value=MOCK_CURRENT_VALUES.copy(),
+            ),
+            patch(
+                "speechwire_mcp.judges.client._post_and_parse",
+                return_value={"success": True, "judge_id": 42, "error": None},
+            ) as mock_post,
+        ):
+            update(42, "new@example.com", MagicMock())
+
+        call_args = mock_post.call_args
+        data = call_args[0][2] if len(call_args[0]) > 2 else call_args[1].get("data")
+        assert data["judgename"] == DONNA_MOSS
+        assert data["teamid"] == "21"
+        assert data["judgeisclean"] == "0"
+        assert data["judgeactive"] == "1"
+        assert data["judgeispriority"] == "0"
+
+    def test_available_slots_preserved(self):
+        update = _import_update_judge_email()
+
+        with (
+            patch(
+                "speechwire_mcp.judges.client._fetch_and_parse",
+                return_value=MOCK_CURRENT_VALUES.copy(),
+            ),
+            patch(
+                "speechwire_mcp.judges.client._post_and_parse",
+                return_value={"success": True, "judge_id": 42, "error": None},
+            ) as mock_post,
+        ):
+            update(42, "new@example.com", MagicMock())
+
+        call_args = mock_post.call_args
+        data = call_args[0][2] if len(call_args[0]) > 2 else call_args[1].get("data")
+        assert data["slotunblock[3]"] == "1"
+        assert data["slotunblock[4]"] == "1"
+        assert "slotunblock[5]" not in data
+
+    def test_extra_fields_preserved(self):
+        update = _import_update_judge_email()
+        mock_values = {
+            "fields": {
+                **MOCK_CURRENT_VALUES["fields"],
+                "judgeiscoach": "1",
+            },
+            "available_slots": MOCK_CURRENT_VALUES["available_slots"],
+        }
+
+        with (
+            patch(
+                "speechwire_mcp.judges.client._fetch_and_parse",
+                return_value=mock_values,
+            ),
+            patch(
+                "speechwire_mcp.judges.client._post_and_parse",
+                return_value={"success": True, "judge_id": 42, "error": None},
+            ) as mock_post,
+        ):
+            update(42, "new@example.com", MagicMock())
+
+        call_args = mock_post.call_args
+        data = (
+            call_args[0][2]
+            if len(call_args[0]) > 2
+            else call_args[1].get("data")
+        )
+        assert data["judgeiscoach"] == "1"
+
+
+# ---------------------------------------------------------------------------
+# Availability form data tests
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateJudgeAvailabilityFormData:
+    def test_slots_are_replaced(self):
+        update = _import_update_judge_availability()
+
+        with (
+            patch(
+                "speechwire_mcp.judges.client._fetch_and_parse",
+                return_value=MOCK_CURRENT_VALUES.copy(),
+            ),
+            patch(
+                "speechwire_mcp.judges.client._post_and_parse",
+                return_value={"success": True, "judge_id": 42, "error": None},
+            ) as mock_post,
+        ):
+            update(42, [5, 6], MagicMock())
+
+        call_args = mock_post.call_args
+        data = call_args[0][2] if len(call_args[0]) > 2 else call_args[1].get("data")
+        assert data["slotunblock[5]"] == "1"
+        assert data["slotunblock[6]"] == "1"
+        assert "slotunblock[3]" not in data
+        assert "slotunblock[4]" not in data
+
+    def test_other_fields_preserved(self):
+        update = _import_update_judge_availability()
+
+        with (
+            patch(
+                "speechwire_mcp.judges.client._fetch_and_parse",
+                return_value=MOCK_CURRENT_VALUES.copy(),
+            ),
+            patch(
+                "speechwire_mcp.judges.client._post_and_parse",
+                return_value={"success": True, "judge_id": 42, "error": None},
+            ) as mock_post,
+        ):
+            update(42, [5], MagicMock())
+
+        call_args = mock_post.call_args
+        data = call_args[0][2] if len(call_args[0]) > 2 else call_args[1].get("data")
+        assert data["judgename"] == DONNA_MOSS
+        assert data["judgeemail"] == email_for(DONNA_MOSS)
+        assert data["teamid"] == "21"
+        assert data["mode"] == "editjudge"
+
+    def test_empty_slots_clears_all(self):
+        update = _import_update_judge_availability()
+
+        with (
+            patch(
+                "speechwire_mcp.judges.client._fetch_and_parse",
+                return_value=MOCK_CURRENT_VALUES.copy(),
+            ),
+            patch(
+                "speechwire_mcp.judges.client._post_and_parse",
+                return_value={"success": True, "judge_id": 42, "error": None},
+            ) as mock_post,
+        ):
+            update(42, [], MagicMock())
+
+        call_args = mock_post.call_args
+        data = call_args[0][2] if len(call_args[0]) > 2 else call_args[1].get("data")
+        slot_keys = [k for k in data if k.startswith("slotunblock")]
+        assert slot_keys == []
+
+
+# ---------------------------------------------------------------------------
+# Prefetch failure tests
+# ---------------------------------------------------------------------------
+
+
+class TestPrefetchFailure:
+    def test_update_email_returns_error_on_prefetch_failure(self):
+        update = _import_update_judge_email()
+
+        with patch(
+            "speechwire_mcp.judges.client._fetch_and_parse",
+            return_value=None,
+        ):
+            result = update(42, "new@example.com", MagicMock())
+
+        assert result["success"] is False
+        assert result["error"] is not None
+        assert "prefetch" in result["error"].lower()
+
+    def test_update_availability_returns_error_on_prefetch_failure(self):
+        update = _import_update_judge_availability()
+
+        with patch(
+            "speechwire_mcp.judges.client._fetch_and_parse",
+            return_value=None,
+        ):
+            result = update(42, [1, 2], MagicMock())
+
+        assert result["success"] is False
+        assert result["error"] is not None
+        assert "prefetch" in result["error"].lower()


### PR DESCRIPTION
## Summary

Add two new MCP tools for updating existing judges:
- `speechwire_update_judge_email` — update a judge's email address
- `speechwire_update_judge_availability` — update a judge's timeslot availability

Both use a **prefetch→merge→POST** pattern: fetch the current edit form, parse all field values, modify only the targeted field, and re-submit the complete form so no existing settings are lost.

## Changes

| File | What |
|------|------|
| `judges/parsers.py` | `parse_edit_form_values()` — form-scoped extraction of all edit page fields; `parse_edit_judge_response()` — success/error detection with sanitized messages |
| `judges/client.py` | `update_judge_email()`, `update_judge_availability()`, plus shared `_prefetch_edit_form` / `_build_edit_form_data` helpers |
| `judges/__init__.py` | New exports |
| `server.py` | Two new `@mcp.tool()` wrappers |
| `tests/test_parsers.py` | Parser tests for both new functions (16 tests) |
| `tests/test_update_judge.py` | Form construction + validation tests (12 tests) |

## Design decisions

- **Form scoping** — parser targets `form#form1` with `mode=editjudge` to avoid contamination from the second `addperiod` form on the page
- **Full field preservation** — serializes all text, select, and hidden inputs (not just a hand-picked subset) so future form changes don't cause silent data loss
- **Sanitized errors** — never forwards raw SpeechWire HTML in error messages (PII protection)
- **Email validation** — rejects malformed emails before making any network requests
- **Prefetch safety** — returns `None` (aborts) if the edit form isn't found, preventing destructive blank POSTs

## Testing

- 248 tests pass, ruff clean
- Reviewed by Charlie (security), Leo (code quality), and Ainsley (parser accuracy)