### PR TITLE
feat: add judge school update tool

### DIFF
--- a/src/speechwire_mcp/judges/__init__.py
+++ b/src/speechwire_mcp/judges/__init__.py
@@ -7,6 +7,7 @@ from speechwire_mcp.judges.client import (
     get_judge_types,
     update_judge_email,
     update_judge_availability,
+    update_judge_school,
 )
 
 __all__ = [
@@ -18,4 +19,5 @@ __all__ = [
     "get_judge_types",
     "update_judge_email",
     "update_judge_availability",
+    "update_judge_school",
 ]

--- a/src/speechwire_mcp/judges/client.py
+++ b/src/speechwire_mcp/judges/client.py
@@ -372,3 +372,53 @@ def update_judge_availability(
         default=_default,
         context=f"update availability for judge {judge_id}",
     )
+
+
+def update_judge_school(
+    judge_id: int,
+    team_id: int,
+    client: SpeechWireClient,
+) -> dict:
+    """Update a judge's school (team) affiliation via the edit form.
+
+    Uses a prefetch→merge→POST pattern because the SpeechWire edit form
+    submits all fields together.
+
+    Parameters
+    ----------
+    judge_id : int
+        ID of the judge to update.
+    team_id : int
+        New team/school ID. Get valid IDs from speechwire_list_teams.
+    client : SpeechWireClient
+        Authenticated client with a tournament selected.
+
+    Returns
+    -------
+    dict
+        ``{"success": bool, "judge_id": int | None, "error": str | None}``
+    """
+    _default: dict = {"success": False, "judge_id": None, "error": "unexpected error"}
+
+    if not team_id:
+        return {
+            "success": False,
+            "judge_id": None,
+            "error": "team_id is required (use speechwire_list_teams to find valid IDs)",
+        }
+
+    current = _prefetch_edit_form(judge_id, client)
+    if current is None:
+        return {"success": False, "judge_id": None, "error": "failed to prefetch edit form"}
+
+    form_data = _build_edit_form_data(judge_id, current, current["available_slots"])
+    form_data["teamid"] = str(team_id)
+
+    return _post_and_parse(
+        client,
+        _EDIT_JUDGE_URL,
+        form_data,
+        parse_edit_judge_response,
+        default=_default,
+        context=f"update school for judge {judge_id}",
+    )

--- a/src/speechwire_mcp/server.py
+++ b/src/speechwire_mcp/server.py
@@ -35,6 +35,7 @@ from speechwire_mcp.judges import (
     get_judge_types,
     update_judge_email,
     update_judge_availability,
+    update_judge_school,
 )
 from speechwire_mcp.schematics import (
     get_schematic_events,
@@ -453,6 +454,33 @@ def speechwire_update_judge_availability(
     return _safe_tool_call(
         lambda: update_judge_availability(judge_id, available_slots, _get_client()),
         f"Failed to update availability for judge {judge_id}",
+        default={"success": False, "judge_id": None, "error": "unexpected error"},
+        require_tournament=True,
+    )
+
+
+@mcp.tool()
+def speechwire_update_judge_school(judge_id: int, team_id: int) -> dict:
+    """Update a judge's school (team) affiliation.
+
+    Prefetches the current edit form, merges the new team ID, and re-submits
+    all fields so that no existing values are lost.
+
+    Parameters
+    ----------
+    judge_id : int
+        ID of the judge to update.
+    team_id : int
+        New team/school ID. Get valid IDs from speechwire_list_teams.
+
+    Returns
+    -------
+    dict
+        ``{"success": bool, "judge_id": int | None, "error": str | None}``
+    """
+    return _safe_tool_call(
+        lambda: update_judge_school(judge_id, team_id, _get_client()),
+        f"Failed to update school for judge {judge_id}",
         default={"success": False, "judge_id": None, "error": "unexpected error"},
         require_tournament=True,
     )

--- a/tests/test_update_judge.py
+++ b/tests/test_update_judge.py
@@ -1,4 +1,4 @@
-"""Tests for update_judge_email and update_judge_availability."""
+"""Tests for update_judge_email, update_judge_availability, and update_judge_school."""
 
 import pytest
 from unittest.mock import MagicMock, patch
@@ -22,6 +22,15 @@ def _import_update_judge_availability():
         return update_judge_availability
     except ImportError:
         pytest.skip("update_judge_availability not implemented yet")
+
+
+def _import_update_judge_school():
+    try:
+        from speechwire_mcp.judges.client import update_judge_school
+
+        return update_judge_school
+    except ImportError:
+        pytest.skip("update_judge_school not implemented yet")
 
 
 MOCK_CURRENT_VALUES = {
@@ -317,4 +326,83 @@ class TestPrefetchFailure:
 
         assert result["success"] is False
         assert result["error"] is not None
+        assert "prefetch" in result["error"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Update school tests
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateJudgeSchoolValidation:
+    def test_rejects_zero_team_id(self):
+        update = _import_update_judge_school()
+        client = MagicMock()
+        result = update(42, 0, client)
+        assert result["success"] is False
+        assert "team_id" in result["error"]
+
+
+class TestUpdateJudgeSchoolFormData:
+    def test_team_id_is_replaced(self):
+        update = _import_update_judge_school()
+
+        with patch(
+            "speechwire_mcp.judges.client._fetch_and_parse",
+            return_value=MOCK_CURRENT_VALUES,
+        ), patch(
+            "speechwire_mcp.judges.client._post_and_parse",
+            return_value={"success": True, "judge_id": 42, "error": None},
+        ) as mock_post:
+            update(42, 99, MagicMock())
+
+        call_args = mock_post.call_args
+        data = call_args[0][2] if len(call_args[0]) > 2 else call_args[1].get("data")
+        assert data["teamid"] == "99"
+
+    def test_other_fields_preserved(self):
+        update = _import_update_judge_school()
+
+        with patch(
+            "speechwire_mcp.judges.client._fetch_and_parse",
+            return_value=MOCK_CURRENT_VALUES,
+        ), patch(
+            "speechwire_mcp.judges.client._post_and_parse",
+            return_value={"success": True, "judge_id": 42, "error": None},
+        ) as mock_post:
+            update(42, 99, MagicMock())
+
+        call_args = mock_post.call_args
+        data = call_args[0][2] if len(call_args[0]) > 2 else call_args[1].get("data")
+        assert data["judgename"] == DONNA_MOSS
+        assert data["judgeemail"] == email_for(DONNA_MOSS)
+        assert data["mode"] == "editjudge"
+
+    def test_available_slots_preserved(self):
+        update = _import_update_judge_school()
+
+        with patch(
+            "speechwire_mcp.judges.client._fetch_and_parse",
+            return_value=MOCK_CURRENT_VALUES,
+        ), patch(
+            "speechwire_mcp.judges.client._post_and_parse",
+            return_value={"success": True, "judge_id": 42, "error": None},
+        ) as mock_post:
+            update(42, 99, MagicMock())
+
+        call_args = mock_post.call_args
+        data = call_args[0][2] if len(call_args[0]) > 2 else call_args[1].get("data")
+        assert data["slotunblock[3]"] == "1"
+        assert data["slotunblock[4]"] == "1"
+
+    def test_prefetch_failure(self):
+        update = _import_update_judge_school()
+
+        with patch(
+            "speechwire_mcp.judges.client._fetch_and_parse",
+            return_value=None,
+        ):
+            result = update(42, 99, MagicMock())
+
+        assert result["success"] is False
         assert "prefetch" in result["error"].lower()


### PR DESCRIPTION
## Summary

Add `speechwire_update_judge_school` MCP tool to change a judge's team/school affiliation. Follows up on #17 which added email and availability updates.

Uses the same **prefetch→merge→POST** pattern — fetches the current edit form, replaces only the `teamid` field, and re-submits all fields.

## Changes

| File | What |
|------|------|
| `judges/client.py` | `update_judge_school()` function |
| `judges/__init__.py` | New export |
| `server.py` | `speechwire_update_judge_school` tool wrapper |
| `tests/test_update_judge.py` | Validation, form construction, field preservation, and prefetch failure tests (5 new tests) |

## Testing

252 tests pass, ruff clean.