### PR TITLE
Replace @x.com with @example.com in test fixtures

### DIFF
--- a/tests/test_client_state.py
+++ b/tests/test_client_state.py
@@ -198,7 +198,7 @@ class TestStateGating:
         from unittest.mock import patch, MagicMock
 
         SpeechWireClient = _import_client()
-        client = SpeechWireClient(email="u@x.com", password="p")
+        client = SpeechWireClient(email="u@example.com", password="p")
 
         expired_resp = MagicMock()
         expired_resp.text = '<input type="password" />'
@@ -271,7 +271,7 @@ class TestRequireTournamentGuard:
         _require_tournament = _import_require_tournament()
 
         client = SpeechWireClient(
-            email="u@x.com", password="p",
+            email="u@example.com", password="p",
             account_id="1", circuit_id="2", tournament_id="3",
         )
         client.state = ClientState.TOURNAMENT_ACTIVE
@@ -286,7 +286,7 @@ class TestRequireTournamentGuard:
         from unittest.mock import patch
 
         client = SpeechWireClient(
-            email="u@x.com", password="p",
+            email="u@example.com", password="p",
             account_id="1", circuit_id="2", tournament_id="3",
         )
         assert client.state == ClientState.UNAUTHENTICATED
@@ -307,7 +307,7 @@ class TestRequireTournamentGuard:
         SpeechWireClient = _import_client()
         _require_tournament = _import_require_tournament()
 
-        client = SpeechWireClient(email="u@x.com", password="p")
+        client = SpeechWireClient(email="u@example.com", password="p")
         result = _require_tournament(client)
         assert result is not None
         assert result["error"] == "no_tournament_selected"
@@ -320,7 +320,7 @@ class TestRequireTournamentGuard:
         from unittest.mock import patch
 
         client = SpeechWireClient(
-            email="u@x.com", password="p",
+            email="u@example.com", password="p",
             account_id="1", circuit_id="2", tournament_id="3",
         )
 

--- a/tests/test_session_expiry.py
+++ b/tests/test_session_expiry.py
@@ -148,7 +148,7 @@ class TestLooksLikeExpiredSession:
         SpeechWireClient = _import_client()
         if not hasattr(SpeechWireClient, "_looks_like_expired_session"):
             pytest.skip("_looks_like_expired_session not implemented yet")
-        client = SpeechWireClient(email="test@x.com", password="p")
+        client = SpeechWireClient(email="test@example.com", password="p")
         return client._looks_like_expired_session(resp)
 
     def test_detects_login_page_with_password_field(self):


### PR DESCRIPTION
x.com is a real domain (Twitter/X), not an RFC 2606 reserved domain. This replaces all 6 instances of `@x.com` with `@example.com` in test files to avoid referencing real services in test data.

**Files changed:**
- `tests/test_client_state.py` (5 instances)
- `tests/test_session_expiry.py` (1 instance)

All 252 tests pass.