### PR TITLE
fix: replace logger.exception() with controlled error messages

### DIFF
--- a/src/speechwire_mcp/server.py
+++ b/src/speechwire_mcp/server.py
@@ -100,8 +100,10 @@ def _require_tournament(client: SpeechWireClient) -> dict | None:
     if client.account_id and client.circuit_id and client.tournament_id:
         try:
             client.ensure_tournament_session()
-        except Exception:
-            logger.exception("Auto-authentication with provided IDs failed")
+        except Exception as exc:
+            logger.error(
+                "Auto-authentication with provided IDs failed: %s", type(exc).__name__
+            )
         if client.state == ClientState.TOURNAMENT_ACTIVE:
             return None
 
@@ -162,8 +164,8 @@ def _safe_tool_call(
                 return guard  # type: ignore[return-value]
 
         return func()
-    except Exception:
-        logger.exception(error_msg)
+    except Exception as exc:
+        logger.error("%s: %s", error_msg, type(exc).__name__)
         return default
 
 


### PR DESCRIPTION
## Summary

Replaces `logger.exception()` with `logger.error()` in `server.py`, logging only the exception class name instead of full tracebacks that could leak URLs (with query params) or session cookies to shared log sinks.

## Changes

- **`_require_tournament` guard** (line 104): `logger.exception(...)` → `logger.error(..., type(exc).__name__)`
- **`_safe_tool_call`** (line 167): `logger.exception(error_msg)` → `logger.error("%s: %s", error_msg, type(exc).__name__)`

## Verification

- `ruff check src/ tests/` — all passed
- `pytest` — 252 tests pass

Closes #21