### PR TITLE
fix: tighten add_judge and edit_judge success heuristics

### DIFF
--- a/src/speechwire_mcp/judges/parsers.py
+++ b/src/speechwire_mcp/judges/parsers.py
@@ -306,13 +306,14 @@ def parse_add_judge_response(html: str) -> dict:
                 if judge_id is not None:
                     break
 
-    body_text = soup.get_text(" ", strip=True).lower()
+    # Rely on structural signals (successmsg div, judge_id) rather than
+    # broad body-text substring matches which can produce false positives.
+    success_text = success_msg.get_text(" ", strip=True).lower() if success_msg else ""
     has_success = (
         success_msg is not None
         or judge_id is not None
-        or "judge added" in body_text
-        or "judge saved" in body_text
-        or "successfully" in body_text
+        or "judge added" in success_text
+        or "judge saved" in success_text
     )
 
     # --- priority: error overrides success ---
@@ -445,11 +446,10 @@ def parse_edit_judge_response(html: str) -> dict:
 
     # --- success signals ---
     success_msg = soup.find("div", class_="successmsg")
-    body_text = soup.get_text(" ", strip=True).lower()
+    success_text = success_msg.get_text(" ", strip=True).lower() if success_msg else ""
     has_success = (
         success_msg is not None
-        or "judge saved" in body_text
-        or "successfully" in body_text
+        or "judge saved" in success_text
     )
 
     if has_error:

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -484,7 +484,7 @@ ADD_JUDGE_SUCCESS_WITH_ID_HTML = f"""<!DOCTYPE html>
 
 ADD_JUDGE_SUCCESS_NO_ID_HTML = """<!DOCTYPE html>
 <html><body>
-  <p>Judge successfully added to the tournament.</p>
+  <div class="successmsg">Judge added to the tournament.</div>
 </body></html>
 """
 
@@ -563,6 +563,17 @@ class TestParseAddJudgeResponse:
         parse = _import_parse_add_judge_response()
         result = parse(ADD_JUDGE_JUDGE_LIST_HTML)
         assert result["success"] is True
+
+    def test_loose_body_text_does_not_trigger_success(self):
+        """Broad strings like 'successfully' in unrelated body text must not match."""
+        parse = _import_parse_add_judge_response()
+        html = """<!DOCTYPE html>
+<html><body>
+  <p>You have successfully logged in.</p>
+  <p>Welcome to SpeechWire.</p>
+</body></html>"""
+        result = parse(html)
+        assert result["success"] is False
 
 
 # ---------------------------------------------------------------------------
@@ -906,7 +917,7 @@ class TestParseEditJudgeResponse:
         parse = _import_parse_edit_judge_response()
         html = """<!DOCTYPE html>
 <html><body>
-<p>judge saved</p>
+<div class="successmsg">Judge saved</div>
 <form id="form1" method="post" action="judges-edit.php">
 <input name='judgeid' type='hidden' value='42' />
 </form></body></html>"""


### PR DESCRIPTION
## Summary

Tightens the success detection in `parse_add_judge_response` and `parse_edit_judge_response` to eliminate false positives from broad body-text substring matching.

## Problem

The parsers used loose checks like `"successfully" in body_text` against the entire page content. These could false-positive if the strings appeared in unrelated page content (e.g., a login banner saying "You have successfully logged in").

## Fix

Success detection now relies only on:
- Presence of a `div.successmsg` element (structural signal)
- Extracted `judge_id` from hidden input or links
- Text scoped *within* the `successmsg` div (not page-wide)

Removed the broad `"successfully"`, `"judge added"`, and `"judge saved"` full-body-text checks from both parsers.

## Tests

- Updated fixtures to use proper `div.successmsg` elements
- Added regression test verifying loose body text no longer triggers false-positive success
- All 253 tests pass

Closes #20